### PR TITLE
feat: add command search and harden session reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Cmd+K quick open has a height-limited, grouped dialog with five recent chats, quick actions, settings, and keyboard hints; search chats and commands together, or start with `>` for commands only
+- Cmd+K quick open has a rounded, height-limited, scrollable dialog with five recent chats, quick actions, settings destinations, workspace/navigation commands, and keyboard hints; search together, or start with `>` for commands only
+- Search project/worktree files with Cmd+P or the Search files quick action, using the same live file source and dialog as the file-tree search
 - New chats can now choose between the main checkout and a fresh isolated worktree directly from the composer
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Cmd+K quick open now switches into a fuzzy-searchable application command mode when the query starts with `>`
 - New chats can now choose between the main checkout and a fresh isolated worktree directly from the composer
 
 ### Changed
@@ -15,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Imported chats, Cloud Workspace setup, approval questions, and permission prompts are denser and easier to scan
 
 ### Fixed
+- Mermaid diagrams on desktop and mobile now reject external-resource syntax before rendering and lock security-sensitive configuration
+- Codex sessions now surface unexpected app-server exits, retire dead provider handles, and allow durable work to restart on a fresh process
+- Desktop packages now include Zuse's license and third-party attribution notices
 - Cloud sandbox images now preconfigure authenticated Git and GitHub CLI access, lazily minting and caching renewable repository credentials only when a GitHub command runs
 - Composer queues now stay held while the app is offline, resume on reconnect, and keep local desktop transports from being marked offline when only browser network connectivity drops
 - Cloud text messages can now be accepted while compute sleeps, wake the workspace through a durable encrypted mailbox, survive client/runtime restarts without duplicate provider sends, and report queued, cancelled, expired, or unknown outcomes explicitly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Cmd+K quick open now switches into a fuzzy-searchable application command mode when the query starts with `>`
+- Cmd+K quick open has a height-limited, grouped dialog with five recent chats, quick actions, settings, and keyboard hints; search chats and commands together, or start with `>` for commands only
 - New chats can now choose between the main checkout and a fresh isolated worktree directly from the composer
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ settings.
 
 ### Layout & UI
 - Three-pane layout: sidebar / chat / files+terminal
-- `Cmd+K` opens a compact palette with five recent chats, quick actions, and settings; search chats and commands together, or type `>` for commands only
+- `Cmd+K` opens a compact, scrollable palette with five recent chats, quick actions, settings destinations, and workspace/navigation commands; search together, or type `>` for commands only
+- `Cmd+P` searches files in the current project or worktree, also available from quick actions and the file-tree header
 - Resizable panes
 - Top bar with active session info
 - PTY terminal (xterm.js + node-pty)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ settings.
 
 ### Layout & UI
 - Three-pane layout: sidebar / chat / files+terminal
+- `Cmd+K` quick open searches chats across projects; type `>` to fuzzy-search application and navigation commands
 - Resizable panes
 - Top bar with active session info
 - PTY terminal (xterm.js + node-pty)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ settings.
 
 ### Layout & UI
 - Three-pane layout: sidebar / chat / files+terminal
-- `Cmd+K` quick open searches chats across projects; type `>` to fuzzy-search application and navigation commands
+- `Cmd+K` opens a compact palette with five recent chats, quick actions, and settings; search chats and commands together, or type `>` for commands only
 - Resizable panes
 - Top bar with active session info
 - PTY terminal (xterm.js + node-pty)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -21,7 +21,7 @@ copied; it records where comparison influenced a decision:
 | [#71](https://github.com/swarajbachu/zuse/pull/71) | Keybinding parser structure and settings interaction patterns; persistence and implementation remain project-specific. |
 | [#72](https://github.com/swarajbachu/zuse/pull/72) | Per-model capability descriptors used as a product/API pattern. |
 | [#111](https://github.com/swarajbachu/zuse/pull/111) | Model catalog, aliases, and capability presentation were cross-checked for feature parity. |
-| [#525](https://github.com/swarajbachu/zuse/pull/525) | macOS awake behavior follows Orca's public Electron power-blocker and `caffeinate` approach; the implementation is project-specific. |
+| [#525](https://github.com/swarajbachu/zuse/pull/525) | macOS awake behavior was cross-checked against public Electron power-blocker and `caffeinate` usage; the implementation is project-specific. |
 
 [PR #79](https://github.com/swarajbachu/zuse/pull/79) separately records a
 deliberate move to a custom diff presentation so the product would have its own
@@ -38,6 +38,22 @@ software:
 The MIT notice below is retained conservatively for the two areas above. It does
 not make Zuse's original code MIT-licensed, and it does not imply that the
 repository as a whole was copied or forked.
+
+## Diagram source validation
+
+The Mermaid unsafe-source policy, tests, and hardened initialization in
+`packages/client-runtime/src/mermaid-source-policy.ts`,
+`packages/client-runtime/test/unit/mermaid-source-policy.test.ts`,
+`apps/renderer/src/components/markdown-body.tsx`, and
+`apps/mobile/src/components/messages/mermaid-diagram.tsx` include adapted
+third-party code.
+
+Copyright (c) 2025-present Mohamed Boudra.
+
+The original material is licensed under `AGPL-3.0-or-later`. Zuse selected version 3,
+modified the material on 2026-08-23, and distributes the resulting work under
+`AGPL-3.0-only`. The complete GNU Affero General Public License version 3 is
+reproduced in [`LICENSE`](LICENSE).
 
 ## Library and framework foundations
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -53,6 +53,10 @@ extraResources:
   - from: resources/skills
     to: app/skills
     filter: ["**/*"]
+  - from: ../../LICENSE
+    to: app/legal/LICENSE
+  - from: ../../THIRD_PARTY_NOTICES.md
+    to: app/legal/THIRD_PARTY_NOTICES.md
 
 # Native bindings can't load from inside an asar; they need to live as
 # real files on disk. electron-builder writes these to app.asar.unpacked/

--- a/apps/mobile/src/components/messages/mermaid-diagram.tsx
+++ b/apps/mobile/src/components/messages/mermaid-diagram.tsx
@@ -1,5 +1,9 @@
 "use dom";
 
+import {
+	containsUnsafeMermaidSource,
+	mermaidSecurityConfig,
+} from "@zuse/client-runtime/mermaid-source-policy";
 import type { DOMProps } from "expo/dom";
 import mermaid from "mermaid";
 import { useEffect, useId, useState } from "react";
@@ -23,16 +27,22 @@ const disableNetworkAccess = (): void => {
 
 export default function MermaidDiagram({ source, dark }: MermaidDiagramProps) {
 	const id = useId().replaceAll(":", "");
+	const unsafeSource = containsUnsafeMermaidSource(source);
 	const [svg, setSvg] = useState<string>();
 	const [error, setError] = useState<string>();
 
 	useEffect(() => {
 		let cancelled = false;
+		if (unsafeSource) {
+			setSvg(undefined);
+			setError("External content is disabled in diagrams.");
+			return () => {
+				cancelled = true;
+			};
+		}
 		disableNetworkAccess();
 		mermaid.initialize({
-			startOnLoad: false,
-			securityLevel: "strict",
-			htmlLabels: false,
+			...mermaidSecurityConfig(),
 			theme: dark ? "dark" : "default",
 		});
 		void mermaid
@@ -53,7 +63,7 @@ export default function MermaidDiagram({ source, dark }: MermaidDiagramProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [dark, id, source]);
+	}, [dark, id, source, unsafeSource]);
 
 	return (
 		<main data-theme={dark ? "dark" : "light"}>

--- a/apps/renderer/src/app.tsx
+++ b/apps/renderer/src/app.tsx
@@ -118,6 +118,11 @@ const ChatSwitcher = lazy(() =>
 		default: module.ChatSwitcher,
 	})),
 );
+const FileSearch = lazy(() =>
+	import("./components/file-search.tsx").then((module) => ({
+		default: module.FileSearch,
+	})),
+);
 const CloudConnectionNotice = lazy(() =>
 	import("./components/cloud-connection-notice.tsx").then((module) => ({
 		default: module.CloudConnectionNotice,
@@ -916,6 +921,7 @@ function MainShell() {
 				<SidebarPeekTrigger />
 				<SidebarPeekOverlay />
 				<ChatSwitcher />
+				<FileSearch />
 			</Suspense>
 		</div>
 	);

--- a/apps/renderer/src/components/chat-switcher.tsx
+++ b/apps/renderer/src/components/chat-switcher.tsx
@@ -1,47 +1,39 @@
+import type { IconSvgElement } from "@hugeicons/react";
 import type { ChatId, Command, FolderId } from "@zuse/contracts";
 import {
-	ArrowDown,
-	ArrowUp,
-	Command as CommandIcon,
-	CornerDownLeft,
-	FolderOpen,
-	MessageSquare,
-	PanelTop,
-	Plus,
-	Search,
-	Settings,
-	Terminal,
-} from "lucide-react";
-import {
-	type KeyboardEvent,
-	useEffect,
-	useId,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
-import { flushSync } from "react-dom";
-import { Dialog, DialogPopup } from "~/components/ui/dialog";
-import { Kbd, KbdGroup } from "~/components/ui/kbd";
+	Add01Icon,
+	BubbleChatIcon,
+	CommandIcon,
+	ComputerTerminal01Icon,
+	FolderOpenIcon,
+	Layout01Icon,
+	Search01Icon,
+	Settings01Icon,
+} from "@zuse/icons/solid-rounded";
+import { useMemo, useState } from "react";
 import {
 	type ChatSwitcherChatRow,
 	type ChatSwitcherRow,
 	chatSwitcherSections,
 } from "~/lib/chat-switcher-items.ts";
 import { formatShortcut } from "~/lib/shortcuts";
-import { cn } from "~/lib/utils";
 import { dispatchCommand } from "../lib/commands.ts";
 import { useActiveEnvironmentEntities } from "../lib/environment-entity-hooks.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
+import {
+	CommandPaletteDialog,
+	type CommandPaletteGroup,
+} from "./ui/command-palette.tsx";
 
-const COMMAND_ICONS: Partial<Record<Command, typeof Plus>> = {
-	"new-chat": Plus,
-	"open-project": FolderOpen,
-	"new-tab": PanelTop,
-	"toggle-terminal": Terminal,
-	settings: Settings,
+const COMMAND_ICONS: Partial<Record<Command, IconSvgElement>> = {
+	"new-chat": Add01Icon,
+	"open-project": FolderOpenIcon,
+	"new-tab": Layout01Icon,
+	"toggle-terminal": ComputerTerminal01Icon,
+	"search-files": Search01Icon,
+	settings: Settings01Icon,
 };
 
 /** Cross-project quick open with bounded recents and shared application commands. */
@@ -77,13 +69,17 @@ function ChatSwitcherInner() {
 			onClose={() => useUiStore.getState().setChatSwitcherOpen(false)}
 			onSelect={(row) => {
 				if (row.kind === "command") dispatchCommand(row.command);
+				else if (row.kind === "settings")
+					useUiStore.setState({
+						view: "settings",
+						settingsSection: row.section,
+					});
 				else useChatsStore.getState().select(row.chat.id);
 			}}
 		/>
 	);
 }
 
-/** The dialog owns search and keyboard navigation; its caller owns navigation. */
 export function ChatSwitcherDialog({
 	chats,
 	selectedChatId,
@@ -95,208 +91,56 @@ export function ChatSwitcherDialog({
 	onClose: () => void;
 	onSelect: (row: ChatSwitcherRow) => void;
 }) {
-	const inputRef = useRef<HTMLInputElement | null>(null);
-	const listRef = useRef<HTMLDivElement | null>(null);
-	const listId = useId();
-	const confirmedRef = useRef(false);
 	const [query, setQuery] = useState("");
-	const sections = useMemo(
+	const groups = useMemo<ReadonlyArray<CommandPaletteGroup<ChatSwitcherRow>>>(
 		() =>
-			chatSwitcherSections(chats, query).filter(
-				(group) => group.rows.length > 0,
-			),
-		[chats, query],
+			chatSwitcherSections(chats, query).map((section) => ({
+				label: section.label,
+				items: section.rows.map((row) => ({
+					id:
+						row.kind === "chat"
+							? row.chat.id
+							: row.kind === "settings"
+								? `settings:${row.section.kind}`
+								: row.command,
+					value: row,
+					label: row.kind === "chat" ? row.title : row.label,
+					icon:
+						row.kind === "chat"
+							? BubbleChatIcon
+							: row.kind === "settings"
+								? row.icon
+								: (COMMAND_ICONS[row.command] ?? CommandIcon),
+					shortcut:
+						row.kind === "command" ? formatShortcut(row.command) : undefined,
+					detail:
+						row.kind === "chat" ? (
+							<>
+								{row.chat.id === selectedChatId && (
+									<span className="shrink-0 text-[11px] text-muted-foreground">
+										Current
+									</span>
+								)}
+								<span className="max-w-[30%] truncate text-xs text-muted-foreground">
+									{row.projectName}
+								</span>
+							</>
+						) : undefined,
+				})),
+			})),
+		[chats, query, selectedChatId],
 	);
-	const rows = useMemo(
-		() => sections.flatMap((group) => group.rows),
-		[sections],
-	);
-	const [highlight, setHighlight] = useState(0);
-	useEffect(() => {
-		setHighlight(0);
-		listRef.current?.scrollTo({ top: 0 });
-	}, [rows]);
-
-	const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-	useEffect(() => {
-		itemRefs.current[highlight]?.scrollIntoView({ block: "nearest" });
-	}, [highlight]);
-
-	const confirm = (row: ChatSwitcherRow | undefined) => {
-		if (row === undefined) return;
-		confirmedRef.current = true;
-		// Focus commands target content made inert by the modal. Unmount the
-		// dialog before dispatch so its focus guard cannot steal the handoff.
-		flushSync(onClose);
-		onSelect(row);
-	};
-
-	const onKey = (event: KeyboardEvent<HTMLInputElement>) => {
-		if (event.nativeEvent.isComposing || rows.length === 0) return;
-		if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-			event.preventDefault();
-			event.stopPropagation();
-			const direction = event.key === "ArrowDown" ? 1 : -1;
-			setHighlight((index) => (index + direction + rows.length) % rows.length);
-		} else if (event.key === "Enter") {
-			event.preventDefault();
-			event.stopPropagation();
-			confirm(rows[highlight]);
-		}
-	};
-
-	let rowIndex = 0;
 	return (
-		<Dialog
-			open
-			onOpenChange={(open) => {
-				if (!open) onClose();
-			}}
-		>
-			<DialogPopup
-				aria-label="Quick open"
-				className="max-h-[min(440px,calc(100dvh-64px))] max-w-xl overflow-hidden"
-				showCloseButton={false}
-				bottomStickOnMobile={false}
-				initialFocus={inputRef}
-				finalFocus={() => !confirmedRef.current}
-			>
-				<div className="flex shrink-0 items-center gap-2.5 border-b border-border/50 px-4 py-2.5 focus-within:border-ring/60">
-					<Search
-						aria-hidden
-						className="size-4 shrink-0 text-muted-foreground"
-					/>
-					<input
-						ref={inputRef}
-						role="combobox"
-						aria-expanded
-						aria-controls={listId}
-						aria-autocomplete="list"
-						aria-activedescendant={
-							rows[highlight] === undefined
-								? undefined
-								: `${listId}-${highlight}`
-						}
-						onKeyDown={onKey}
-						value={query}
-						onChange={(event) => setQuery(event.target.value)}
-						aria-label="Search chats and commands"
-						placeholder="Search chats or run a command…"
-						className="h-7 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-					/>
-				</div>
-				<div
-					ref={listRef}
-					id={listId}
-					role="listbox"
-					tabIndex={-1}
-					aria-label="Chats and commands"
-					className="min-h-0 overflow-y-auto overscroll-contain p-1.5"
-				>
-					{sections.length === 0 ? (
-						<div className="px-4 py-8 text-center text-sm">
-							<p>No results found</p>
-							<p className="mt-1 text-xs text-muted-foreground">
-								Try another chat, project, or command name.
-							</p>
-						</div>
-					) : (
-						sections.map((section, sectionIndex) => (
-							<fieldset
-								key={section.label}
-								aria-labelledby={`${listId}-group-${sectionIndex}`}
-								className="min-w-0 pb-1 last:pb-0 [&+&]:border-t [&+&]:border-border/40 [&+&]:pt-1"
-							>
-								<div
-									id={`${listId}-group-${sectionIndex}`}
-									className="px-2.5 py-1 text-[11px] font-medium leading-4 text-muted-foreground"
-								>
-									{section.label}
-								</div>
-								{section.rows.map((row) => {
-									const index = rowIndex++;
-									const Icon =
-										row.kind === "chat"
-											? MessageSquare
-											: (COMMAND_ICONS[row.command] ?? CommandIcon);
-									const shortcut =
-										row.kind === "command" ? formatShortcut(row.command) : "";
-									return (
-										<button
-											key={row.kind === "chat" ? row.chat.id : row.command}
-											ref={(element) => {
-												itemRefs.current[index] = element;
-											}}
-											type="button"
-											role="option"
-											id={`${listId}-${index}`}
-											tabIndex={-1}
-											onMouseDown={(event) => event.preventDefault()}
-											aria-selected={index === highlight}
-											onMouseMove={() => setHighlight(index)}
-											onClick={() => confirm(row)}
-											className={cn(
-												"flex h-7 w-full items-center gap-2.5 rounded-md px-2.5 text-left text-[13px] outline-none focus-visible:ring-1 focus-visible:ring-ring",
-												index === highlight
-													? "bg-accent text-accent-foreground"
-													: "hover:bg-muted/60",
-											)}
-										>
-											<Icon
-												aria-hidden
-												className="size-3.5 shrink-0 text-muted-foreground"
-											/>
-											<span className="min-w-0 flex-1 truncate">
-												{row.kind === "chat" ? row.title : row.label}
-											</span>
-											{row.kind === "chat" ? (
-												<>
-													{row.chat.id === selectedChatId && (
-														<span className="shrink-0 text-[11px] text-muted-foreground">
-															Current
-														</span>
-													)}
-													<span className="max-w-[30%] truncate text-xs text-muted-foreground">
-														{row.projectName}
-													</span>
-												</>
-											) : shortcut ? (
-												<Kbd className="h-4 bg-transparent px-0 text-[11px]">
-													{shortcut}
-												</Kbd>
-											) : null}
-										</button>
-									);
-								})}
-							</fieldset>
-						))
-					)}
-				</div>
-				<div className="flex shrink-0 items-center justify-between gap-3 border-t border-border/50 bg-muted/30 px-4 py-2 text-[11px] text-muted-foreground">
-					<div className="flex items-center gap-3">
-						<span className="flex items-center gap-1.5">
-							<KbdGroup>
-								<Kbd>
-									<ArrowUp aria-label="Up arrow" />
-								</Kbd>
-								<Kbd>
-									<ArrowDown aria-label="Down arrow" />
-								</Kbd>
-							</KbdGroup>
-							Navigate
-						</span>
-						<span className="flex items-center gap-1.5">
-							<Kbd>
-								<CornerDownLeft aria-label="Enter" />
-							</Kbd>
-							Open
-						</span>
-					</div>
-					<span className="flex items-center gap-1.5">
-						<Kbd>Esc</Kbd>Close
-					</span>
-				</div>
-			</DialogPopup>
-		</Dialog>
+		<CommandPaletteDialog
+			label="Quick open"
+			inputLabel="Search chats and commands"
+			placeholder="Search chats or run a command…"
+			query={query}
+			onQueryChange={setQuery}
+			groups={groups}
+			onClose={onClose}
+			onSelect={onSelect}
+			emptyMessage="No results found. Try another chat, project, or command name."
+		/>
 	);
 }

--- a/apps/renderer/src/components/chat-switcher.tsx
+++ b/apps/renderer/src/components/chat-switcher.tsx
@@ -1,5 +1,17 @@
-import type { Chat, FolderId } from "@zuse/contracts";
-import fuzzysort from "fuzzysort";
+import type { ChatId, Command, FolderId } from "@zuse/contracts";
+import {
+	ArrowDown,
+	ArrowUp,
+	Command as CommandIcon,
+	CornerDownLeft,
+	FolderOpen,
+	MessageSquare,
+	PanelTop,
+	Plus,
+	Search,
+	Settings,
+	Terminal,
+} from "lucide-react";
 import {
 	type KeyboardEvent,
 	useEffect,
@@ -10,239 +22,279 @@ import {
 } from "react";
 import { flushSync } from "react-dom";
 import { Dialog, DialogPopup } from "~/components/ui/dialog";
-import { cn } from "~/lib/utils";
+import { Kbd, KbdGroup } from "~/components/ui/kbd";
 import {
-	type ChatSwitcherCommandRow,
-	commandRowsForQuery,
-	commandSearchQuery,
-} from "../lib/chat-switcher-commands.ts";
+	type ChatSwitcherChatRow,
+	type ChatSwitcherRow,
+	chatSwitcherSections,
+} from "~/lib/chat-switcher-items.ts";
+import { formatShortcut } from "~/lib/shortcuts";
+import { cn } from "~/lib/utils";
 import { dispatchCommand } from "../lib/commands.ts";
 import { useActiveEnvironmentEntities } from "../lib/environment-entity-hooks.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 
-/**
- * Cross-project quick open (Cmd+K). Its default mode lists every non-archived
- * chat across every project; prefixing the query with `>` instead searches
- * safe application commands from the shared command registry. Selecting a
- * chat in another project automatically switches the active project too —
- * that's handled inside `useChatsStore.select`.
- *
- * Modeled on the keyboard-list pattern in `composer/slash-command-popover.tsx`
- * (fuzzysort + arrow-key highlight) but presented as a centered modal.
- */
+const COMMAND_ICONS: Partial<Record<Command, typeof Plus>> = {
+	"new-chat": Plus,
+	"open-project": FolderOpen,
+	"new-tab": PanelTop,
+	"toggle-terminal": Terminal,
+	settings: Settings,
+};
+
+/** Cross-project quick open with bounded recents and shared application commands. */
 export function ChatSwitcher() {
 	const open = useUiStore((s) => s.chatSwitcherOpen);
 	if (!open) return null;
 	return <ChatSwitcherInner />;
 }
 
-interface ChatRow {
-	readonly kind: "chat";
-	readonly chat: Chat;
-	readonly projectId: FolderId;
-	readonly projectName: string;
-	/** Pre-lowercased title used for the empty-query recents label / fuzzy keys. */
-	readonly title: string;
-}
-
-type Row = ChatRow | ChatSwitcherCommandRow;
-
-const recencyOf = (chat: Chat): number =>
-	(chat.lastMessageAt ?? chat.updatedAt ?? chat.createdAt).getTime();
-
 function ChatSwitcherInner() {
 	const folders = useWorkspaceStore((s) => s.folders);
 	const { chatsByProject } = useActiveEnvironmentEntities();
 	const selectedChatId = useChatsStore((s) => s.selectedChatId);
-	const inputRef = useRef<HTMLInputElement | null>(null);
-	const listId = useId();
-	const confirmedRef = useRef(false);
-
-	const close = () => useUiStore.getState().setChatSwitcherOpen(false);
-
-	// All non-archived chats across all projects, with their project name.
-	const allRows = useMemo<ReadonlyArray<ChatRow>>(() => {
-		const projectName = new Map<FolderId, string>(
-			folders.map((f) => [f.id, f.name]),
+	const chats = useMemo<ReadonlyArray<ChatSwitcherChatRow>>(() => {
+		const projectNames = new Map<FolderId, string>(
+			folders.map((folder) => [folder.id, folder.name]),
 		);
-		const rows: ChatRow[] = [];
-		for (const [pid, chats] of Object.entries(chatsByProject)) {
-			const folderId = pid as FolderId;
-			for (const chat of chats) {
-				if (chat.archivedAt !== null) continue;
-				rows.push({
-					kind: "chat",
-					chat,
-					projectId: folderId,
-					projectName: projectName.get(folderId) ?? "Unknown project",
-					title: chat.title.length > 0 ? chat.title : "New chat",
-				});
-			}
-		}
-		return rows;
+		return Object.entries(chatsByProject).flatMap(([projectId, entries]) =>
+			entries.map((chat) => ({
+				kind: "chat" as const,
+				chat,
+				projectName:
+					projectNames.get(projectId as FolderId) ?? "Unknown project",
+				title: chat.title.length > 0 ? chat.title : "New chat",
+			})),
+		);
 	}, [folders, chatsByProject]);
 
+	return (
+		<ChatSwitcherDialog
+			chats={chats}
+			selectedChatId={selectedChatId}
+			onClose={() => useUiStore.getState().setChatSwitcherOpen(false)}
+			onSelect={(row) => {
+				if (row.kind === "command") dispatchCommand(row.command);
+				else useChatsStore.getState().select(row.chat.id);
+			}}
+		/>
+	);
+}
+
+/** The dialog owns search and keyboard navigation; its caller owns navigation. */
+export function ChatSwitcherDialog({
+	chats,
+	selectedChatId,
+	onClose,
+	onSelect,
+}: {
+	chats: ReadonlyArray<ChatSwitcherChatRow>;
+	selectedChatId: ChatId | null;
+	onClose: () => void;
+	onSelect: (row: ChatSwitcherRow) => void;
+}) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const listRef = useRef<HTMLDivElement | null>(null);
+	const listId = useId();
+	const confirmedRef = useRef(false);
 	const [query, setQuery] = useState("");
-	const commandMode = commandSearchQuery(query) !== null;
-
-	const rows = useMemo<ReadonlyArray<Row>>(() => {
-		if (commandMode) return commandRowsForQuery(query);
-		if (query.trim().length === 0) {
-			// Recents first across all projects.
-			return allRows
-				.slice()
-				.sort((a, b) => recencyOf(b.chat) - recencyOf(a.chat));
-		}
-		const ranked = fuzzysort.go(query, allRows, {
-			keys: ["title", "projectName"],
-			threshold: 0.3,
-			limit: 50,
-		});
-		return ranked.map((r) => r.obj);
-	}, [allRows, commandMode, query]);
-
+	const sections = useMemo(
+		() =>
+			chatSwitcherSections(chats, query).filter(
+				(group) => group.rows.length > 0,
+			),
+		[chats, query],
+	);
+	const rows = useMemo(
+		() => sections.flatMap((group) => group.rows),
+		[sections],
+	);
 	const [highlight, setHighlight] = useState(0);
-	useEffect(() => setHighlight(0), [rows]);
+	useEffect(() => {
+		setHighlight(0);
+		listRef.current?.scrollTo({ top: 0 });
+	}, [rows]);
 
 	const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 	useEffect(() => {
 		itemRefs.current[highlight]?.scrollIntoView({ block: "nearest" });
 	}, [highlight]);
 
-	const confirm = (row: Row | undefined) => {
+	const confirm = (row: ChatSwitcherRow | undefined) => {
 		if (row === undefined) return;
 		confirmedRef.current = true;
 		// Focus commands target content made inert by the modal. Unmount the
 		// dialog before dispatch so its focus guard cannot steal the handoff.
-		flushSync(close);
-		if (row.kind === "command") {
-			dispatchCommand(row.command);
-			return;
-		}
-		useChatsStore.getState().select(row.chat.id);
+		flushSync(onClose);
+		onSelect(row);
 	};
 
-	const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
-		if (e.nativeEvent.isComposing) return;
-		if (rows.length === 0) return;
-		if (e.key === "ArrowDown") {
-			e.preventDefault();
-			e.stopPropagation();
-			setHighlight((h) => (h + 1) % rows.length);
-		} else if (e.key === "ArrowUp") {
-			e.preventDefault();
-			e.stopPropagation();
-			setHighlight((h) => (h - 1 + rows.length) % rows.length);
-		} else if (e.key === "Enter") {
-			e.preventDefault();
-			e.stopPropagation();
+	const onKey = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.nativeEvent.isComposing || rows.length === 0) return;
+		if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+			event.preventDefault();
+			event.stopPropagation();
+			const direction = event.key === "ArrowDown" ? 1 : -1;
+			setHighlight((index) => (index + direction + rows.length) % rows.length);
+		} else if (event.key === "Enter") {
+			event.preventDefault();
+			event.stopPropagation();
 			confirm(rows[highlight]);
 		}
 	};
 
+	let rowIndex = 0;
 	return (
 		<Dialog
 			open
 			onOpenChange={(open) => {
-				if (!open) close();
+				if (!open) onClose();
 			}}
 		>
 			<DialogPopup
 				aria-label="Quick open"
-				className="max-w-xl overflow-hidden"
+				className="max-h-[min(440px,calc(100dvh-64px))] max-w-xl overflow-hidden"
 				showCloseButton={false}
 				bottomStickOnMobile={false}
 				initialFocus={inputRef}
 				finalFocus={() => !confirmedRef.current}
 			>
-				<input
-					ref={inputRef}
-					role="combobox"
-					aria-expanded
-					aria-controls={listId}
-					aria-autocomplete="list"
-					aria-activedescendant={
-						rows[highlight] === undefined ? undefined : `${listId}-${highlight}`
-					}
-					onKeyDown={onKey}
-					value={query}
-					onChange={(e) => setQuery(e.target.value)}
-					aria-label="Search chats and commands"
-					placeholder="Search chats… Type > for commands"
-					className="h-7 w-full shrink-0 border-b border-border/60 bg-transparent px-3.5 text-sm outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring placeholder:text-muted-foreground"
-				/>
+				<div className="flex shrink-0 items-center gap-2.5 border-b border-border/50 px-4 py-2.5 focus-within:border-ring/60">
+					<Search
+						aria-hidden
+						className="size-4 shrink-0 text-muted-foreground"
+					/>
+					<input
+						ref={inputRef}
+						role="combobox"
+						aria-expanded
+						aria-controls={listId}
+						aria-autocomplete="list"
+						aria-activedescendant={
+							rows[highlight] === undefined
+								? undefined
+								: `${listId}-${highlight}`
+						}
+						onKeyDown={onKey}
+						value={query}
+						onChange={(event) => setQuery(event.target.value)}
+						aria-label="Search chats and commands"
+						placeholder="Search chats or run a command…"
+						className="h-7 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+					/>
+				</div>
 				<div
+					ref={listRef}
 					id={listId}
 					role="listbox"
 					tabIndex={-1}
-					aria-label={commandMode ? "Commands" : "Chats"}
-					className="min-h-0 flex-1 overflow-y-auto p-1.5"
+					aria-label="Chats and commands"
+					className="min-h-0 overflow-y-auto overscroll-contain p-1.5"
 				>
-					{rows.length === 0 ? (
-						<p className="px-4 py-6 text-center text-sm text-muted-foreground">
-							{commandMode ? "No commands found." : "No chats found."}
-						</p>
+					{sections.length === 0 ? (
+						<div className="px-4 py-8 text-center text-sm">
+							<p>No results found</p>
+							<p className="mt-1 text-xs text-muted-foreground">
+								Try another chat, project, or command name.
+							</p>
+						</div>
 					) : (
-						rows.map((row, i) => {
-							const active = i === highlight;
-							const isCurrent =
-								row.kind === "chat" && row.chat.id === selectedChatId;
-							return (
-								<button
-									key={
-										row.kind === "chat" ? row.chat.id : `command:${row.command}`
-									}
-									ref={(el) => {
-										itemRefs.current[i] = el;
-									}}
-									type="button"
-									role="option"
-									id={`${listId}-${i}`}
-									tabIndex={-1}
-									onMouseDown={(e) => e.preventDefault()}
-									aria-selected={active}
-									onMouseEnter={() => setHighlight(i)}
-									onClick={() => confirm(row)}
-									className={cn(
-										"flex h-7 w-full items-center gap-3 rounded-lg px-2.5 text-left text-sm",
-										active
-											? "bg-accent text-accent-foreground"
-											: "hover:bg-muted/60",
-									)}
+						sections.map((section, sectionIndex) => (
+							<fieldset
+								key={section.label}
+								aria-labelledby={`${listId}-group-${sectionIndex}`}
+								className="min-w-0 pb-1 last:pb-0 [&+&]:border-t [&+&]:border-border/40 [&+&]:pt-1"
+							>
+								<div
+									id={`${listId}-group-${sectionIndex}`}
+									className="px-2.5 py-1 text-[11px] font-medium leading-4 text-muted-foreground"
 								>
-									{row.kind === "command" ? (
-										<>
-											<span className="min-w-0 flex-1 truncate text-foreground">
-												{row.label}
-												<span className="ml-2 text-xs text-muted-foreground">
-													{row.description}
-												</span>
-											</span>
-											<span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
-												{row.group}
-											</span>
-										</>
-									) : (
-										<>
-											<span className="min-w-0 flex-1 truncate text-foreground">
-												{row.title}
-											</span>
-											{isCurrent && (
-												<span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
-													current
-												</span>
+									{section.label}
+								</div>
+								{section.rows.map((row) => {
+									const index = rowIndex++;
+									const Icon =
+										row.kind === "chat"
+											? MessageSquare
+											: (COMMAND_ICONS[row.command] ?? CommandIcon);
+									const shortcut =
+										row.kind === "command" ? formatShortcut(row.command) : "";
+									return (
+										<button
+											key={row.kind === "chat" ? row.chat.id : row.command}
+											ref={(element) => {
+												itemRefs.current[index] = element;
+											}}
+											type="button"
+											role="option"
+											id={`${listId}-${index}`}
+											tabIndex={-1}
+											onMouseDown={(event) => event.preventDefault()}
+											aria-selected={index === highlight}
+											onMouseMove={() => setHighlight(index)}
+											onClick={() => confirm(row)}
+											className={cn(
+												"flex h-7 w-full items-center gap-2.5 rounded-md px-2.5 text-left text-[13px] outline-none focus-visible:ring-1 focus-visible:ring-ring",
+												index === highlight
+													? "bg-accent text-accent-foreground"
+													: "hover:bg-muted/60",
 											)}
-											<span className="shrink-0 truncate text-xs text-muted-foreground">
-												{row.projectName}
+										>
+											<Icon
+												aria-hidden
+												className="size-3.5 shrink-0 text-muted-foreground"
+											/>
+											<span className="min-w-0 flex-1 truncate">
+												{row.kind === "chat" ? row.title : row.label}
 											</span>
-										</>
-									)}
-								</button>
-							);
-						})
+											{row.kind === "chat" ? (
+												<>
+													{row.chat.id === selectedChatId && (
+														<span className="shrink-0 text-[11px] text-muted-foreground">
+															Current
+														</span>
+													)}
+													<span className="max-w-[30%] truncate text-xs text-muted-foreground">
+														{row.projectName}
+													</span>
+												</>
+											) : shortcut ? (
+												<Kbd className="h-4 bg-transparent px-0 text-[11px]">
+													{shortcut}
+												</Kbd>
+											) : null}
+										</button>
+									);
+								})}
+							</fieldset>
+						))
 					)}
+				</div>
+				<div className="flex shrink-0 items-center justify-between gap-3 border-t border-border/50 bg-muted/30 px-4 py-2 text-[11px] text-muted-foreground">
+					<div className="flex items-center gap-3">
+						<span className="flex items-center gap-1.5">
+							<KbdGroup>
+								<Kbd>
+									<ArrowUp aria-label="Up arrow" />
+								</Kbd>
+								<Kbd>
+									<ArrowDown aria-label="Down arrow" />
+								</Kbd>
+							</KbdGroup>
+							Navigate
+						</span>
+						<span className="flex items-center gap-1.5">
+							<Kbd>
+								<CornerDownLeft aria-label="Enter" />
+							</Kbd>
+							Open
+						</span>
+					</div>
+					<span className="flex items-center gap-1.5">
+						<Kbd>Esc</Kbd>Close
+					</span>
 				</div>
 			</DialogPopup>
 		</Dialog>

--- a/apps/renderer/src/components/chat-switcher.tsx
+++ b/apps/renderer/src/components/chat-switcher.tsx
@@ -1,4 +1,4 @@
-import type { IconSvgElement } from "@hugeicons/react";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import type { ChatId, Command, FolderId } from "@zuse/contracts";
 import {
 	Add01Icon,
@@ -105,12 +105,19 @@ export function ChatSwitcherDialog({
 								: row.command,
 					value: row,
 					label: row.kind === "chat" ? row.title : row.label,
-					icon:
-						row.kind === "chat"
-							? BubbleChatIcon
-							: row.kind === "settings"
-								? row.icon
-								: (COMMAND_ICONS[row.command] ?? CommandIcon),
+					icon: (
+						<HugeiconsIcon
+							icon={
+								row.kind === "chat"
+									? BubbleChatIcon
+									: row.kind === "settings"
+										? row.icon
+										: (COMMAND_ICONS[row.command] ?? CommandIcon)
+							}
+							aria-hidden
+							className="size-4 shrink-0 text-muted-foreground"
+						/>
+					),
 					shortcut:
 						row.kind === "command" ? formatShortcut(row.command) : undefined,
 					detail:

--- a/apps/renderer/src/components/chat-switcher.tsx
+++ b/apps/renderer/src/components/chat-switcher.tsx
@@ -1,19 +1,33 @@
 import type { Chat, FolderId } from "@zuse/contracts";
 import fuzzysort from "fuzzysort";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { overlaySurface } from "~/components/ui/overlay-surface";
+import {
+	type KeyboardEvent,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { flushSync } from "react-dom";
+import { Dialog, DialogPopup } from "~/components/ui/dialog";
 import { cn } from "~/lib/utils";
+import {
+	type ChatSwitcherCommandRow,
+	commandRowsForQuery,
+	commandSearchQuery,
+} from "../lib/chat-switcher-commands.ts";
+import { dispatchCommand } from "../lib/commands.ts";
 import { useActiveEnvironmentEntities } from "../lib/environment-entity-hooks.ts";
 import { useChatsStore } from "../store/chats.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
 
 /**
- * Cross-project chat quick-switcher (Cmd+K). Lists every non-archived chat
- * across every project; fuzzy-search by chat title or project name, then jump
- * with Enter. Selecting a chat in another project automatically switches the
- * active project too — that's handled inside `useChatsStore.select`, so this
- * component just decides *which* chat and calls it.
+ * Cross-project quick open (Cmd+K). Its default mode lists every non-archived
+ * chat across every project; prefixing the query with `>` instead searches
+ * safe application commands from the shared command registry. Selecting a
+ * chat in another project automatically switches the active project too —
+ * that's handled inside `useChatsStore.select`.
  *
  * Modeled on the keyboard-list pattern in `composer/slash-command-popover.tsx`
  * (fuzzysort + arrow-key highlight) but presented as a centered modal.
@@ -24,13 +38,16 @@ export function ChatSwitcher() {
 	return <ChatSwitcherInner />;
 }
 
-interface Row {
+interface ChatRow {
+	readonly kind: "chat";
 	readonly chat: Chat;
 	readonly projectId: FolderId;
 	readonly projectName: string;
 	/** Pre-lowercased title used for the empty-query recents label / fuzzy keys. */
 	readonly title: string;
 }
+
+type Row = ChatRow | ChatSwitcherCommandRow;
 
 const recencyOf = (chat: Chat): number =>
 	(chat.lastMessageAt ?? chat.updatedAt ?? chat.createdAt).getTime();
@@ -39,30 +56,24 @@ function ChatSwitcherInner() {
 	const folders = useWorkspaceStore((s) => s.folders);
 	const { chatsByProject } = useActiveEnvironmentEntities();
 	const selectedChatId = useChatsStore((s) => s.selectedChatId);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const listId = useId();
+	const confirmedRef = useRef(false);
 
 	const close = () => useUiStore.getState().setChatSwitcherOpen(false);
 
-	// Restore focus to wherever the user was when they opened the switcher,
-	// but only when they dismiss without picking (selecting navigates focus).
-	const prevFocusRef = useRef<HTMLElement | null>(null);
-	useEffect(() => {
-		prevFocusRef.current = document.activeElement as HTMLElement | null;
-		return () => {
-			// no-op cleanup; explicit restore happens in `dismiss`.
-		};
-	}, []);
-
 	// All non-archived chats across all projects, with their project name.
-	const allRows = useMemo<ReadonlyArray<Row>>(() => {
+	const allRows = useMemo<ReadonlyArray<ChatRow>>(() => {
 		const projectName = new Map<FolderId, string>(
 			folders.map((f) => [f.id, f.name]),
 		);
-		const rows: Row[] = [];
+		const rows: ChatRow[] = [];
 		for (const [pid, chats] of Object.entries(chatsByProject)) {
 			const folderId = pid as FolderId;
 			for (const chat of chats) {
 				if (chat.archivedAt !== null) continue;
 				rows.push({
+					kind: "chat",
 					chat,
 					projectId: folderId,
 					projectName: projectName.get(folderId) ?? "Unknown project",
@@ -74,8 +85,10 @@ function ChatSwitcherInner() {
 	}, [folders, chatsByProject]);
 
 	const [query, setQuery] = useState("");
+	const commandMode = commandSearchQuery(query) !== null;
 
 	const rows = useMemo<ReadonlyArray<Row>>(() => {
+		if (commandMode) return commandRowsForQuery(query);
 		if (query.trim().length === 0) {
 			// Recents first across all projects.
 			return allRows
@@ -88,7 +101,7 @@ function ChatSwitcherInner() {
 			limit: 50,
 		});
 		return ranked.map((r) => r.obj);
-	}, [allRows, query]);
+	}, [allRows, commandMode, query]);
 
 	const [highlight, setHighlight] = useState(0);
 	useEffect(() => setHighlight(0), [rows]);
@@ -98,109 +111,140 @@ function ChatSwitcherInner() {
 		itemRefs.current[highlight]?.scrollIntoView({ block: "nearest" });
 	}, [highlight]);
 
-	const dismiss = () => {
-		close();
-		prevFocusRef.current?.focus?.();
-	};
-
 	const confirm = (row: Row | undefined) => {
 		if (row === undefined) return;
-		close();
+		confirmedRef.current = true;
+		// Focus commands target content made inert by the modal. Unmount the
+		// dialog before dispatch so its focus guard cannot steal the handoff.
+		flushSync(close);
+		if (row.kind === "command") {
+			dispatchCommand(row.command);
+			return;
+		}
 		useChatsStore.getState().select(row.chat.id);
 	};
 
-	useEffect(() => {
-		const onKey = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				e.preventDefault();
-				e.stopPropagation();
-				dismiss();
-				return;
-			}
-			if (rows.length === 0) return;
-			if (e.key === "ArrowDown") {
-				e.preventDefault();
-				e.stopPropagation();
-				setHighlight((h) => (h + 1) % rows.length);
-			} else if (e.key === "ArrowUp") {
-				e.preventDefault();
-				e.stopPropagation();
-				setHighlight((h) => (h - 1 + rows.length) % rows.length);
-			} else if (e.key === "Enter") {
-				e.preventDefault();
-				e.stopPropagation();
-				confirm(rows[highlight]);
-			}
-		};
-		window.addEventListener("keydown", onKey, true);
-		return () => window.removeEventListener("keydown", onKey, true);
-	}, [rows, highlight]);
+	const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.nativeEvent.isComposing) return;
+		if (rows.length === 0) return;
+		if (e.key === "ArrowDown") {
+			e.preventDefault();
+			e.stopPropagation();
+			setHighlight((h) => (h + 1) % rows.length);
+		} else if (e.key === "ArrowUp") {
+			e.preventDefault();
+			e.stopPropagation();
+			setHighlight((h) => (h - 1 + rows.length) % rows.length);
+		} else if (e.key === "Enter") {
+			e.preventDefault();
+			e.stopPropagation();
+			confirm(rows[highlight]);
+		}
+	};
 
 	return (
-		<div
-			className="fixed inset-0 z-50 flex justify-center bg-black/40 px-4 py-[12vh] backdrop-blur-sm"
-			onMouseDown={dismiss}
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open) close();
+			}}
 		>
-			<div
-				role="dialog"
-				aria-label="Switch chat"
-				className={cn(
-					"flex h-fit max-h-full w-full max-w-xl flex-col overflow-hidden",
-					overlaySurface,
-				)}
-				onMouseDown={(e) => e.stopPropagation()}
+			<DialogPopup
+				aria-label="Quick open"
+				className="max-w-xl overflow-hidden"
+				showCloseButton={false}
+				bottomStickOnMobile={false}
+				initialFocus={inputRef}
+				finalFocus={() => !confirmedRef.current}
 			>
 				<input
-					autoFocus
+					ref={inputRef}
+					role="combobox"
+					aria-expanded
+					aria-controls={listId}
+					aria-autocomplete="list"
+					aria-activedescendant={
+						rows[highlight] === undefined ? undefined : `${listId}-${highlight}`
+					}
+					onKeyDown={onKey}
 					value={query}
 					onChange={(e) => setQuery(e.target.value)}
-					placeholder="Search chats across all projects…"
-					className="w-full shrink-0 border-b border-border/60 bg-transparent px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground"
+					aria-label="Search chats and commands"
+					placeholder="Search chats… Type > for commands"
+					className="h-7 w-full shrink-0 border-b border-border/60 bg-transparent px-3.5 text-sm outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring placeholder:text-muted-foreground"
 				/>
-				<div role="listbox" className="min-h-0 flex-1 overflow-y-auto p-1.5">
+				<div
+					id={listId}
+					role="listbox"
+					tabIndex={-1}
+					aria-label={commandMode ? "Commands" : "Chats"}
+					className="min-h-0 flex-1 overflow-y-auto p-1.5"
+				>
 					{rows.length === 0 ? (
 						<p className="px-4 py-6 text-center text-sm text-muted-foreground">
-							No chats found.
+							{commandMode ? "No commands found." : "No chats found."}
 						</p>
 					) : (
 						rows.map((row, i) => {
 							const active = i === highlight;
-							const isCurrent = row.chat.id === selectedChatId;
+							const isCurrent =
+								row.kind === "chat" && row.chat.id === selectedChatId;
 							return (
 								<button
-									key={row.chat.id}
+									key={
+										row.kind === "chat" ? row.chat.id : `command:${row.command}`
+									}
 									ref={(el) => {
 										itemRefs.current[i] = el;
 									}}
 									type="button"
 									role="option"
+									id={`${listId}-${i}`}
+									tabIndex={-1}
+									onMouseDown={(e) => e.preventDefault()}
 									aria-selected={active}
 									onMouseEnter={() => setHighlight(i)}
 									onClick={() => confirm(row)}
 									className={cn(
-										"flex min-h-8 w-full items-center gap-3 rounded-lg px-2.5 py-1.5 text-left text-sm",
+										"flex h-7 w-full items-center gap-3 rounded-lg px-2.5 text-left text-sm",
 										active
 											? "bg-accent text-accent-foreground"
 											: "hover:bg-muted/60",
 									)}
 								>
-									<span className="min-w-0 flex-1 truncate text-foreground">
-										{row.title}
-									</span>
-									{isCurrent && (
-										<span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
-											current
-										</span>
+									{row.kind === "command" ? (
+										<>
+											<span className="min-w-0 flex-1 truncate text-foreground">
+												{row.label}
+												<span className="ml-2 text-xs text-muted-foreground">
+													{row.description}
+												</span>
+											</span>
+											<span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+												{row.group}
+											</span>
+										</>
+									) : (
+										<>
+											<span className="min-w-0 flex-1 truncate text-foreground">
+												{row.title}
+											</span>
+											{isCurrent && (
+												<span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+													current
+												</span>
+											)}
+											<span className="shrink-0 truncate text-xs text-muted-foreground">
+												{row.projectName}
+											</span>
+										</>
 									)}
-									<span className="shrink-0 truncate text-xs text-muted-foreground">
-										{row.projectName}
-									</span>
 								</button>
 							);
 						})
 					)}
 				</div>
-			</div>
-		</div>
+			</DialogPopup>
+		</Dialog>
 	);
 }

--- a/apps/renderer/src/components/file-search.tsx
+++ b/apps/renderer/src/components/file-search.tsx
@@ -1,6 +1,5 @@
 import type { ExecutionRef } from "@zuse/client-runtime/resource-ref";
 import type { FolderId } from "@zuse/contracts";
-import { File01Icon } from "@zuse/icons/solid-rounded";
 import { useMemo, useState } from "react";
 import {
 	fileSearchFeedback,
@@ -12,6 +11,7 @@ import { useFileTreeResource } from "../lib/file-tree-resource-hooks.ts";
 import { useActiveContext } from "../store/active-workspace.ts";
 import { useUiStore } from "../store/ui.ts";
 import { useWorkspaceStore } from "../store/workspace.ts";
+import { FileIcon } from "./file-icon.tsx";
 import { CommandPaletteDialog } from "./ui/command-palette.tsx";
 
 const close = () => useUiStore.getState().setFileSearchOpen(false);
@@ -101,7 +101,13 @@ export function FileSearchDialog({
 					id: path,
 					value: path,
 					label: path.split("/").at(-1) ?? path,
-					icon: File01Icon,
+					icon: (
+						<FileIcon
+							name={path}
+							kind="file"
+							className="inline-flex size-4 shrink-0 items-center justify-center"
+						/>
+					),
 					detail: (
 						<span className="max-w-[45%] truncate text-xs text-muted-foreground">
 							{path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : ""}

--- a/apps/renderer/src/components/file-search.tsx
+++ b/apps/renderer/src/components/file-search.tsx
@@ -1,0 +1,134 @@
+import type { ExecutionRef } from "@zuse/client-runtime/resource-ref";
+import type { FolderId } from "@zuse/contracts";
+import { File01Icon } from "@zuse/icons/solid-rounded";
+import { useMemo, useState } from "react";
+import {
+	fileSearchFeedback,
+	fileSearchResults,
+	searchableFiles,
+	searchedFileTarget,
+} from "../lib/file-search.ts";
+import { useFileTreeResource } from "../lib/file-tree-resource-hooks.ts";
+import { useActiveContext } from "../store/active-workspace.ts";
+import { useUiStore } from "../store/ui.ts";
+import { useWorkspaceStore } from "../store/workspace.ts";
+import { CommandPaletteDialog } from "./ui/command-palette.tsx";
+
+const close = () => useUiStore.getState().setFileSearchOpen(false);
+
+export function FileSearch() {
+	const open = useUiStore((state) => state.fileSearchOpen);
+	return open ? <ActiveFileSearch /> : null;
+}
+
+function ActiveFileSearch() {
+	const context = useActiveContext();
+	const projectId = useWorkspaceStore((state) => state.selectedFolderId);
+	if (
+		context.status !== "ready" ||
+		context.worktreePending ||
+		projectId === null
+	) {
+		const message =
+			context.status === "empty"
+				? "Open a project to search its files."
+				: context.status === "cloud-unavailable"
+					? "Reconnect this cloud workspace to search its files."
+					: "Waiting for the project or worktree to become available…";
+		return (
+			<FileSearchDialog
+				files={[]}
+				onClose={close}
+				onSelect={() => {}}
+				emptyMessage={message}
+			/>
+		);
+	}
+	return (
+		<ProjectFileSearch
+			key={`${context.environmentId}:${context.folderId}:${context.worktreeId}:${context.rootPath}`}
+			execution={context}
+			projectId={projectId}
+		/>
+	);
+}
+
+function ProjectFileSearch({
+	execution,
+	projectId,
+}: {
+	execution: ExecutionRef;
+	projectId: FolderId;
+}) {
+	const view = useFileTreeResource(execution);
+	const files = useMemo(
+		() => searchableFiles(view.data?.paths ?? []),
+		[view.data?.paths],
+	);
+	return (
+		<FileSearchDialog
+			files={files}
+			onClose={close}
+			onSelect={(path) => {
+				const ui = useUiStore.getState();
+				ui.setView("chat");
+				ui.openFileInTab(searchedFileTarget(execution, projectId, path));
+			}}
+			{...fileSearchFeedback(view)}
+		/>
+	);
+}
+
+export function FileSearchDialog({
+	files,
+	onClose,
+	onSelect,
+	emptyMessage,
+	notice,
+}: {
+	files: ReadonlyArray<string>;
+	onClose: () => void;
+	onSelect: (path: string) => void;
+	emptyMessage?: string;
+	notice?: string;
+}) {
+	const [query, setQuery] = useState("");
+	const groups = useMemo(
+		() => [
+			{
+				label: "Project files",
+				items: fileSearchResults(files, query).map((path) => ({
+					id: path,
+					value: path,
+					label: path.split("/").at(-1) ?? path,
+					icon: File01Icon,
+					detail: (
+						<span className="max-w-[45%] truncate text-xs text-muted-foreground">
+							{path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : ""}
+						</span>
+					),
+				})),
+			},
+		],
+		[files, query],
+	);
+	return (
+		<CommandPaletteDialog
+			label="Search project files"
+			inputLabel="Search files"
+			placeholder="Search files…"
+			query={query}
+			onQueryChange={setQuery}
+			groups={groups}
+			onClose={onClose}
+			onSelect={onSelect}
+			emptyMessage={
+				emptyMessage ??
+				(query.trim()
+					? "No files match your search."
+					: "No files in this project.")
+			}
+			notice={notice}
+		/>
+	);
+}

--- a/apps/renderer/src/components/file-tree.tsx
+++ b/apps/renderer/src/components/file-tree.tsx
@@ -27,31 +27,16 @@ import {
 	PencilEdit01Icon,
 	Search01Icon,
 } from "@zuse/icons/solid-rounded";
-import fuzzysort from "fuzzysort";
 import { ChevronRight } from "lucide-react";
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	useSyncExternalStore,
-} from "react";
-
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { OpenTarget } from "../lib/bridge.ts";
-import {
-	dispatchFileTreeCommand,
-	fileTreeResourceKey,
-	fileTreeResourceSnapshot,
-	retainFileTreeResource,
-	subscribeFileTreeResource,
-} from "../lib/file-tree-client-bus.ts";
+import { dispatchFileTreeCommand } from "../lib/file-tree-client-bus.ts";
+import { useFileTreeResource } from "../lib/file-tree-resource-hooks.ts";
 import { useGitChangesResource } from "../lib/git-workspace-client-bus.ts";
 import { useSettingsStore } from "../lib/settings-client-bus.ts";
 import { cn } from "../lib/utils.ts";
 import { useComposerBridge } from "../store/composer-bridge.ts";
 import { useUiStore } from "../store/ui.ts";
-import { FileIcon } from "./file-icon.tsx";
 import { OpenTargetIcon } from "./open-target-icon.tsx";
 import {
 	AlertDialog,
@@ -196,22 +181,12 @@ export function FileTree({
 	rootPath: string;
 	worktreeId: WorktreeId | null;
 }) {
-	const key = useMemo(
-		() =>
-			fileTreeResourceKey({ environmentId, folderId, worktreeId, rootPath }),
-		[environmentId, folderId, rootPath, worktreeId],
-	);
-	useEffect(() => {
-		const retained = retainFileTreeResource(key);
-		return () => {
-			retained.lease.release();
-		};
-	}, [key]);
-	const view = useSyncExternalStore(
-		(listener) => subscribeFileTreeResource(key, listener),
-		() => fileTreeResourceSnapshot(key),
-		() => fileTreeResourceSnapshot(key),
-	);
+	const view = useFileTreeResource({
+		environmentId,
+		folderId,
+		worktreeId,
+		rootPath,
+	});
 
 	if (view.data === null) {
 		if (view.sync === "failed" || view.connection === "failed") {
@@ -300,12 +275,6 @@ function TreeView({
 			setOpenTargets(targets.filter((target) => target.available));
 		});
 	}, [folderRoot]);
-
-	// Non-null while the file-search command palette is open; holds the current
-	// file list (dirs excluded) captured from the live known-paths set.
-	const [searchFiles, setSearchFiles] = useState<ReadonlyArray<string> | null>(
-		null,
-	);
 
 	// Directory paths carry a trailing "/" in the server listing. Keep a set of
 	// their canonical (slash-stripped) form so selection can tell files from
@@ -652,13 +621,6 @@ function TreeView({
 		],
 	);
 
-	const openSearch = useCallback(() => {
-		const files = Array.from(knownPathsRef.current)
-			.filter((p) => !p.endsWith("/"))
-			.sort((a, b) => a.localeCompare(b));
-		setSearchFiles(files);
-	}, []);
-
 	const header = (
 		<div className="flex items-center gap-1 px-2 py-1.5">
 			<span className="flex-1 truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -677,7 +639,7 @@ function TreeView({
 			<HeaderButton
 				label="Search files"
 				icon={Search01Icon}
-				onClick={openSearch}
+				onClick={() => useUiStore.getState().setFileSearchOpen(true)}
 			/>
 		</div>
 	);
@@ -705,145 +667,7 @@ function TreeView({
 				}}
 				onConfirm={confirmDelete}
 			/>
-			{searchFiles !== null ? (
-				<FileSearchPalette
-					files={searchFiles}
-					onClose={() => setSearchFiles(null)}
-					onSelect={(path) => {
-						setSearchFiles(null);
-						openFile(path, basename(path));
-					}}
-				/>
-			) : null}
 		</div>
-	);
-}
-
-/**
- * Command-palette file finder opened from the tree header's search button.
- * Fuzzy-matches the workspace's file list and opens the picked file. Separate
- * from the tree's own row filter so search is a fast global jump, not an
- * in-place filter.
- */
-function FileSearchPalette({
-	files,
-	onSelect,
-	onClose,
-}: {
-	files: ReadonlyArray<string>;
-	onSelect: (path: string) => void;
-	onClose: () => void;
-}) {
-	const [query, setQuery] = useState("");
-	const [highlight, setHighlight] = useState(0);
-	const inputRef = useRef<HTMLInputElement | null>(null);
-	const listRef = useRef<HTMLDivElement | null>(null);
-
-	useEffect(() => {
-		inputRef.current?.focus();
-	}, []);
-
-	const results = useMemo<ReadonlyArray<string>>(() => {
-		const q = query.trim();
-		if (q === "") return files.slice(0, 100);
-		return fuzzysort
-			.go(q, files as string[], { limit: 100, threshold: 0.4 })
-			.map((r) => r.target);
-	}, [files, query]);
-
-	useEffect(() => {
-		setHighlight(0);
-	}, [results]);
-
-	useEffect(() => {
-		const el = listRef.current?.querySelector(`[data-idx="${highlight}"]`);
-		el?.scrollIntoView({ block: "nearest" });
-	}, [highlight]);
-
-	const commit = (idx: number) => {
-		const path = results[idx];
-		if (path !== undefined) onSelect(path);
-	};
-
-	return (
-		<dialog
-			open
-			aria-label="Search project files"
-			className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-[12vh]"
-			onMouseDown={(event) => {
-				if (event.target === event.currentTarget) onClose();
-			}}
-		>
-			<div
-				className={cn(
-					"flex max-h-[62vh] w-[min(680px,92vw)] flex-col overflow-hidden",
-					overlaySurface,
-				)}
-			>
-				<div className="flex items-center gap-2 border-b border-border/60 px-3">
-					<HugeiconsIcon
-						icon={Search01Icon}
-						className="size-4 shrink-0 text-muted-foreground"
-					/>
-					<input
-						ref={inputRef}
-						value={query}
-						onChange={(e) => setQuery(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Escape") {
-								e.preventDefault();
-								onClose();
-							} else if (e.key === "ArrowDown") {
-								e.preventDefault();
-								setHighlight((h) => Math.min(h + 1, results.length - 1));
-							} else if (e.key === "ArrowUp") {
-								e.preventDefault();
-								setHighlight((h) => Math.max(h - 1, 0));
-							} else if (e.key === "Enter") {
-								e.preventDefault();
-								commit(highlight);
-							}
-						}}
-						placeholder="Search files…"
-						className="flex-1 bg-transparent py-3 text-sm text-foreground outline-none placeholder:text-muted-foreground"
-					/>
-				</div>
-				<div ref={listRef} className="min-h-0 flex-1 overflow-y-auto p-1">
-					{results.length === 0 ? (
-						<p className="px-3 py-6 text-center text-xs text-muted-foreground">
-							No files match “{query}”.
-						</p>
-					) : (
-						results.map((path, idx) => {
-							const name = basename(path);
-							const dir = parentPathOf(path);
-							return (
-								<button
-									key={path}
-									data-idx={idx}
-									type="button"
-									onMouseEnter={() => setHighlight(idx)}
-									onClick={() => commit(idx)}
-									className={`flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left ${
-										idx === highlight ? "bg-accent text-accent-foreground" : ""
-									}`}
-								>
-									<FileIcon name={name} kind="file" />
-									<span className="truncate font-mono text-[13px] text-foreground">
-										{name}
-									</span>
-									{dir !== "" ? (
-										<span className="truncate font-mono text-[11px] text-muted-foreground">
-											{dir}
-										</span>
-									) : null}
-								</button>
-							);
-						})
-					)}
-				</div>
-			</div>
-		</dialog>
 	);
 }
 

--- a/apps/renderer/src/components/markdown-body.tsx
+++ b/apps/renderer/src/components/markdown-body.tsx
@@ -1,5 +1,9 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
+	containsUnsafeMermaidSource,
+	mermaidSecurityConfig,
+} from "@zuse/client-runtime/mermaid-source-policy";
+import {
 	Maximize02Icon,
 	MoveIcon,
 	UndoIcon,
@@ -201,13 +205,7 @@ let mermaidId = 0;
 const getMermaid = (): Promise<MermaidApi> => {
 	mermaidPromise ??= import("mermaid").then(({ default: mermaid }) => {
 		mermaid.initialize({
-			startOnLoad: false,
-			securityLevel: "strict",
-			// Never let mermaid draw its built-in "bomb" error graphic into the DOM.
-			// On a parse failure it otherwise appends that SVG to document.body,
-			// which renders as a bar below the app and shoves the window upward.
-			// With this on, render() just throws and our own error UI takes over.
-			suppressErrorRendering: true,
+			...mermaidSecurityConfig(),
 			theme: "base",
 			themeVariables: {
 				background: "transparent",
@@ -428,6 +426,7 @@ function MermaidViewerDialog({
 }
 
 function MermaidDiagram({ source }: { source: string }) {
+	const unsafeSource = containsUnsafeMermaidSource(source);
 	const id = useMemo(() => {
 		mermaidId += 1;
 		return `markdown-mermaid-${mermaidId}`;
@@ -441,6 +440,15 @@ function MermaidDiagram({ source }: { source: string }) {
 
 	useEffect(() => {
 		let cancelled = false;
+		if (unsafeSource) {
+			setState({
+				status: "error",
+				message: "External content is disabled in diagrams.",
+			});
+			return () => {
+				cancelled = true;
+			};
+		}
 		setState({ status: "loading" });
 
 		void getMermaid()
@@ -470,7 +478,7 @@ function MermaidDiagram({ source }: { source: string }) {
 		return () => {
 			cancelled = true;
 		};
-	}, [id, source]);
+	}, [id, source, unsafeSource]);
 
 	if (state.status === "error") {
 		return (

--- a/apps/renderer/src/components/settings-page.tsx
+++ b/apps/renderer/src/components/settings-page.tsx
@@ -16,19 +16,9 @@ import {
 } from "@zuse/contracts";
 import {
 	Alert01Icon,
-	BrowserIcon,
-	ConnectIcon,
 	Delete02Icon,
-	DocumentAttachmentIcon,
 	Folder01Icon,
-	KeyboardIcon,
-	PackageIcon,
 	PencilEdit01Icon,
-	PlugSocketIcon,
-	Settings01Icon,
-	SmartPhone01Icon,
-	TaskDone01Icon,
-	TestTubeIcon,
 	Tick01Icon,
 	VolumeHighIcon,
 } from "@zuse/icons/solid-rounded";
@@ -39,6 +29,7 @@ import { displayPath } from "~/lib/display-path";
 import { hasHostCapability, isMacHost } from "~/lib/host-platform";
 import { rendererPlatformCapabilities } from "~/lib/platform-capabilities.ts";
 import { isInitialProviderAvailabilityLoading } from "~/lib/provider-status";
+import { SETTINGS_NAVIGATION as VISIBLE_RAIL } from "~/lib/settings-navigation.ts";
 import {
 	formatRelativeTime,
 	useRelativeTimeTick,
@@ -108,98 +99,7 @@ import {
 } from "./ui/select.tsx";
 import { Switch } from "./ui/switch";
 
-type RailItemBase = {
-	readonly id: string;
-	readonly label: string;
-	readonly Icon: IconSvgElement;
-	readonly section: SettingsSection;
-};
-
-const TOP_RAIL: ReadonlyArray<RailItemBase> = [
-	{
-		id: "general",
-		label: "General",
-		Icon: Settings01Icon,
-		section: { kind: "general" },
-	},
-	{
-		id: "providers",
-		label: "Providers",
-		Icon: PackageIcon,
-		section: { kind: "providers" },
-	},
-	{
-		id: "defaults",
-		label: "Default models",
-		Icon: TaskDone01Icon,
-		section: { kind: "defaults" },
-	},
-	{
-		id: "mcp",
-		label: "MCP Servers",
-		Icon: PlugSocketIcon,
-		section: { kind: "mcp" },
-	},
-	{
-		id: "integrations",
-		label: "Integrations",
-		Icon: ConnectIcon,
-		section: { kind: "integrations" },
-	},
-	{
-		id: "devices",
-		label: "Remote access",
-		Icon: SmartPhone01Icon,
-		section: { kind: "devices" },
-	},
-	{
-		id: "machines",
-		label: "Cloud workspaces · Beta",
-		Icon: ConnectIcon,
-		section: { kind: "machines" },
-	},
-	{
-		id: "browser",
-		label: "Browser",
-		Icon: BrowserIcon,
-		section: { kind: "browser" },
-	},
-	{
-		id: "pokedex",
-		label: "Pokedex",
-		Icon: TaskDone01Icon,
-		section: { kind: "pokedex" },
-	},
-	{
-		id: "shortcuts",
-		label: "Keyboard shortcuts",
-		Icon: KeyboardIcon,
-		section: { kind: "shortcuts" },
-	},
-	{
-		id: "diagnostics",
-		label: "Diagnostics",
-		Icon: DocumentAttachmentIcon,
-		section: { kind: "diagnostics" },
-	},
-	// Dev-only visual playground (accent swatches + workflow chip/button
-	// showcase). Filtered out of production bundles below.
-	{
-		id: "developer",
-		label: "Developer",
-		Icon: TestTubeIcon,
-		section: { kind: "developer" },
-	},
-];
-
 const CLOUD_MACHINES_AVAILABLE = cloudWorkspaceBetaAvailable();
-
-const VISIBLE_RAIL: ReadonlyArray<RailItemBase> = TOP_RAIL.filter(
-	(item) =>
-		(item.id !== "developer" || import.meta.env.DEV) &&
-		(item.id !== "machines" || CLOUD_MACHINES_AVAILABLE),
-);
-
 /**
  * Two-pane settings surface. The left rail navigates between global
  * sections (General / Models & Providers / Workspace) and per-repository

--- a/apps/renderer/src/components/ui/command-palette.tsx
+++ b/apps/renderer/src/components/ui/command-palette.tsx
@@ -1,0 +1,249 @@
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import {
+	ArrowDown02Icon,
+	ArrowTurnDownIcon,
+	ArrowUp02Icon,
+	Search01Icon,
+} from "@zuse/icons/solid-rounded";
+import {
+	type KeyboardEvent,
+	type ReactNode,
+	useEffect,
+	useId,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { flushSync } from "react-dom";
+import { cn } from "~/lib/utils";
+import { Dialog, DialogPopup } from "./dialog";
+import { Kbd, KbdGroup } from "./kbd";
+
+export interface CommandPaletteItem<Value> {
+	readonly id: string;
+	readonly label: string;
+	readonly icon: IconSvgElement;
+	readonly value: Value;
+	readonly detail?: ReactNode;
+	readonly shortcut?: string;
+}
+
+export interface CommandPaletteGroup<Value> {
+	readonly label: string;
+	readonly items: ReadonlyArray<CommandPaletteItem<Value>>;
+}
+
+/** Shared command-dialog surface: rounded inset panel, bounded scroll, one focus owner. */
+export function CommandPaletteDialog<Value>({
+	label,
+	inputLabel,
+	placeholder,
+	query,
+	onQueryChange,
+	groups,
+	onClose,
+	onSelect,
+	emptyMessage = "Try another chat, project, or command name.",
+	notice,
+}: {
+	label: string;
+	inputLabel: string;
+	placeholder: string;
+	query: string;
+	onQueryChange: (query: string) => void;
+	groups: ReadonlyArray<CommandPaletteGroup<Value>>;
+	onClose: () => void;
+	onSelect: (value: Value) => void;
+	emptyMessage?: string;
+	notice?: string;
+}) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const listRef = useRef<HTMLDivElement | null>(null);
+	const listId = useId();
+	const confirmedRef = useRef(false);
+	const rows = useMemo(() => groups.flatMap((group) => group.items), [groups]);
+	const [highlight, setHighlight] = useState(0);
+	const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+	useEffect(() => {
+		setHighlight(0);
+		listRef.current?.scrollTo({ top: 0 });
+	}, [rows]);
+	useEffect(() => {
+		itemRefs.current[highlight]?.scrollIntoView({ block: "nearest" });
+	}, [highlight]);
+
+	const confirm = (item: CommandPaletteItem<Value> | undefined) => {
+		if (item === undefined) return;
+		confirmedRef.current = true;
+		// Unmount before dispatch: commands may focus content made inert by this modal.
+		flushSync(onClose);
+		onSelect(item.value);
+	};
+	const onKey = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.nativeEvent.isComposing || rows.length === 0) return;
+		if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+			event.preventDefault();
+			event.stopPropagation();
+			const direction = event.key === "ArrowDown" ? 1 : -1;
+			setHighlight((index) => (index + direction + rows.length) % rows.length);
+		} else if (event.key === "Enter") {
+			event.preventDefault();
+			event.stopPropagation();
+			confirm(rows[highlight]);
+		}
+	};
+	let rowIndex = 0;
+	return (
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open) onClose();
+			}}
+		>
+			<DialogPopup
+				aria-label={label}
+				className="max-h-[min(440px,calc(100dvh-64px))] max-w-xl overflow-hidden rounded-2xl bg-muted"
+				showCloseButton={false}
+				bottomStickOnMobile={false}
+				initialFocus={inputRef}
+				finalFocus={() => !confirmedRef.current}
+			>
+				<div className="flex shrink-0 items-center gap-2.5 px-4 py-3">
+					<HugeiconsIcon
+						icon={Search01Icon}
+						aria-hidden
+						className="size-4 shrink-0 text-muted-foreground"
+					/>
+					<input
+						ref={inputRef}
+						role="combobox"
+						aria-expanded={rows.length > 0}
+						aria-controls={listId}
+						aria-autocomplete="list"
+						aria-activedescendant={
+							rows[highlight] === undefined
+								? undefined
+								: `${listId}-${highlight}`
+						}
+						onKeyDown={onKey}
+						value={query}
+						onChange={(event) => onQueryChange(event.target.value)}
+						aria-label={inputLabel}
+						placeholder={placeholder}
+						className="h-7 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+					/>
+				</div>
+				<div className="flex min-h-0 flex-col overflow-hidden rounded-t-2xl border-t border-border/70 bg-popover">
+					{notice && (
+						<p
+							role="status"
+							className="shrink-0 px-4 pt-3 text-xs text-muted-foreground"
+						>
+							{notice}
+						</p>
+					)}
+					<div
+						ref={listRef}
+						id={listId}
+						role="listbox"
+						hidden={rows.length === 0}
+						tabIndex={-1}
+						aria-label={label}
+						className="min-h-0 overflow-y-auto overscroll-contain p-1.5 [scrollbar-width:thin]"
+					>
+						{rows.length === 0
+							? null
+							: groups.map((group, groupIndex) =>
+									group.items.length === 0 ? null : (
+										<fieldset
+											key={group.label}
+											aria-labelledby={`${listId}-group-${groupIndex}`}
+											className="min-w-0 pb-2 last:pb-1 [&+&]:pt-1"
+										>
+											<div
+												id={`${listId}-group-${groupIndex}`}
+												className="px-2.5 py-2 text-xs font-medium text-muted-foreground"
+											>
+												{group.label}
+											</div>
+											{group.items.map((item) => {
+												const index = rowIndex++;
+												return (
+													<button
+														key={item.id}
+														ref={(element) => {
+															itemRefs.current[index] = element;
+														}}
+														type="button"
+														role="option"
+														id={`${listId}-${index}`}
+														tabIndex={-1}
+														onMouseDown={(event) => event.preventDefault()}
+														aria-selected={index === highlight}
+														onMouseMove={() => setHighlight(index)}
+														onClick={() => confirm(item)}
+														className={cn(
+															"flex h-7 w-full items-center gap-2.5 rounded-lg px-2.5 text-left text-[13px] outline-none focus-visible:ring-1 focus-visible:ring-ring",
+															index === highlight
+																? "bg-accent text-accent-foreground"
+																: "hover:bg-muted/60",
+														)}
+													>
+														<HugeiconsIcon
+															icon={item.icon}
+															aria-hidden
+															className="size-4 shrink-0 text-muted-foreground"
+														/>
+														<span className="min-w-0 flex-1 truncate">
+															{item.label}
+														</span>
+														{item.detail}
+														{item.shortcut && (
+															<Kbd className="h-4 shrink-0 rounded-full bg-muted/70 px-1.5 text-[11px]">
+																{item.shortcut}
+															</Kbd>
+														)}
+													</button>
+												);
+											})}
+										</fieldset>
+									),
+								)}
+					</div>
+					{rows.length === 0 && (
+						<p role="status" className="px-4 pb-8 pt-5 text-center text-sm">
+							{emptyMessage}
+						</p>
+					)}
+					<div className="flex shrink-0 items-center justify-between gap-3 border-t border-border/40 px-4 py-2 text-[11px] text-muted-foreground">
+						<div className="flex items-center gap-3">
+							<span className="flex items-center gap-1.5">
+								<KbdGroup>
+									<Kbd>
+										<HugeiconsIcon icon={ArrowUp02Icon} aria-label="Up arrow" />
+									</Kbd>
+									<Kbd>
+										<HugeiconsIcon
+											icon={ArrowDown02Icon}
+											aria-label="Down arrow"
+										/>
+									</Kbd>
+								</KbdGroup>
+								Navigate
+							</span>
+							<span className="flex items-center gap-1.5">
+								<Kbd>
+									<HugeiconsIcon icon={ArrowTurnDownIcon} aria-label="Enter" />
+								</Kbd>
+								Open
+							</span>
+						</div>
+						<span className="flex items-center gap-1.5">
+							<Kbd>Esc</Kbd>Close
+						</span>
+					</div>
+				</div>
+			</DialogPopup>
+		</Dialog>
+	);
+}

--- a/apps/renderer/src/components/ui/command-palette.tsx
+++ b/apps/renderer/src/components/ui/command-palette.tsx
@@ -1,4 +1,4 @@
-import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	ArrowDown02Icon,
 	ArrowTurnDownIcon,
@@ -22,7 +22,7 @@ import { Kbd, KbdGroup } from "./kbd";
 export interface CommandPaletteItem<Value> {
 	readonly id: string;
 	readonly label: string;
-	readonly icon: IconSvgElement;
+	readonly icon: ReactNode;
 	readonly value: Value;
 	readonly detail?: ReactNode;
 	readonly shortcut?: string;
@@ -189,11 +189,7 @@ export function CommandPaletteDialog<Value>({
 																: "hover:bg-muted/60",
 														)}
 													>
-														<HugeiconsIcon
-															icon={item.icon}
-															aria-hidden
-															className="size-4 shrink-0 text-muted-foreground"
-														/>
+														{item.icon}
 														<span className="min-w-0 flex-1 truncate">
 															{item.label}
 														</span>

--- a/apps/renderer/src/lib/chat-switcher-commands.ts
+++ b/apps/renderer/src/lib/chat-switcher-commands.ts
@@ -1,0 +1,62 @@
+import type { Command } from "@zuse/contracts";
+import fuzzysort from "fuzzysort";
+import { APPLICATION_COMMANDS } from "./commands.ts";
+import { COMMAND_META, COMMANDS_IN_ORDER } from "./default-keybindings.ts";
+
+const COMMAND_PREFIX = ">";
+
+/** Commands that would be circular or inert when launched from quick open. */
+const EXCLUDED_COMMANDS: ReadonlySet<Command> = new Set(["open-chat-switcher"]);
+
+export interface ChatSwitcherCommandRow {
+	readonly kind: "command";
+	readonly command: Command;
+	readonly label: string;
+	readonly description: string;
+	readonly group: string;
+	readonly searchText: string;
+}
+
+const ALL_COMMAND_ROWS: ReadonlyArray<ChatSwitcherCommandRow> =
+	COMMANDS_IN_ORDER.flatMap((command) => {
+		if (!APPLICATION_COMMANDS.has(command) || EXCLUDED_COMMANDS.has(command))
+			return [];
+		const metadata = COMMAND_META[command];
+		return [
+			{
+				kind: "command" as const,
+				command,
+				label: metadata.label,
+				description: metadata.description,
+				group: metadata.group,
+				searchText:
+					`${metadata.label} ${metadata.description} ${metadata.group}`.toLowerCase(),
+			},
+		];
+	});
+
+/** Returns the command query after `>`, or `null` while quick open is in chat mode. */
+export function commandSearchQuery(query: string): string | null {
+	const trimmedStart = query.trimStart();
+	if (!trimmedStart.startsWith(COMMAND_PREFIX)) return null;
+	return trimmedStart.slice(COMMAND_PREFIX.length).trim();
+}
+
+/**
+ * Project safe global commands into quick-open rows. The global registry owns
+ * availability and ordering; this helper owns only the `>` mode and ranking.
+ */
+export function commandRowsForQuery(
+	query: string,
+): ReadonlyArray<ChatSwitcherCommandRow> {
+	const searchQuery = commandSearchQuery(query);
+	if (searchQuery === null) return [];
+	if (searchQuery.length === 0) return ALL_COMMAND_ROWS;
+	return fuzzysort
+		.go(searchQuery, ALL_COMMAND_ROWS, {
+			key: "searchText",
+			threshold: 0.3,
+			limit: 50,
+		})
+		.map((result) => result.obj);
+}

--- a/apps/renderer/src/lib/chat-switcher-items.ts
+++ b/apps/renderer/src/lib/chat-switcher-items.ts
@@ -1,10 +1,13 @@
+import type { IconSvgElement } from "@hugeicons/react";
 import type { Chat, Command } from "@zuse/contracts";
 import fuzzysort from "fuzzysort";
+import type { SettingsSection } from "../store/ui.ts";
 import {
 	type ChatSwitcherCommandRow,
 	commandRowsForQuery,
 	commandSearchQuery,
 } from "./chat-switcher-commands.ts";
+import { SETTINGS_NAVIGATION } from "./settings-navigation.ts";
 
 export interface ChatSwitcherChatRow {
 	readonly kind: "chat";
@@ -13,7 +16,16 @@ export interface ChatSwitcherChatRow {
 	readonly title: string;
 }
 
-export type ChatSwitcherRow = ChatSwitcherChatRow | ChatSwitcherCommandRow;
+export interface ChatSwitcherSettingsRow {
+	readonly kind: "settings";
+	readonly label: string;
+	readonly icon: IconSvgElement;
+	readonly section: SettingsSection;
+}
+export type ChatSwitcherRow =
+	| ChatSwitcherChatRow
+	| ChatSwitcherCommandRow
+	| ChatSwitcherSettingsRow;
 
 export interface ChatSwitcherSection {
 	readonly label: string;
@@ -25,8 +37,18 @@ const SEARCH_LIMIT = 20;
 const QUICK_ACTIONS: ReadonlySet<Command> = new Set([
 	"new-chat",
 	"open-project",
+	"search-files",
+	"new-tab",
 	"toggle-terminal",
 ]);
+
+const SETTINGS_ROWS: ReadonlyArray<ChatSwitcherSettingsRow> =
+	SETTINGS_NAVIGATION.map((item) => ({
+		kind: "settings",
+		label: item.label,
+		icon: item.Icon,
+		section: item.section,
+	}));
 
 const recencyOf = ({ chat }: ChatSwitcherChatRow): number =>
 	(chat.lastMessageAt ?? chat.updatedAt ?? chat.createdAt).getTime();
@@ -55,6 +77,12 @@ export function chatSwitcherSections(
 					.map((result) => result.obj),
 			},
 			{ label: "Commands", rows: commandRowsForQuery(`>${search}`) },
+			{
+				label: "Settings",
+				rows: fuzzysort
+					.go(search, SETTINGS_ROWS, { key: "label", threshold: 0.3 })
+					.map((result) => result.obj),
+			},
 		];
 	}
 
@@ -72,7 +100,22 @@ export function chatSwitcherSections(
 		},
 		{
 			label: "Settings",
-			rows: commands.filter((row) => row.command === "settings"),
+			rows: SETTINGS_ROWS,
+		},
+		{
+			label: "Workspace",
+			rows: commands.filter(
+				(row) =>
+					row.group === "Application" &&
+					!QUICK_ACTIONS.has(row.command) &&
+					row.command !== "settings",
+			),
+		},
+		{
+			label: "Navigation",
+			rows: commands.filter(
+				(row) => row.group === "Navigation" && !QUICK_ACTIONS.has(row.command),
+			),
 		},
 	];
 }

--- a/apps/renderer/src/lib/chat-switcher-items.ts
+++ b/apps/renderer/src/lib/chat-switcher-items.ts
@@ -1,0 +1,78 @@
+import type { Chat, Command } from "@zuse/contracts";
+import fuzzysort from "fuzzysort";
+import {
+	type ChatSwitcherCommandRow,
+	commandRowsForQuery,
+	commandSearchQuery,
+} from "./chat-switcher-commands.ts";
+
+export interface ChatSwitcherChatRow {
+	readonly kind: "chat";
+	readonly chat: Chat;
+	readonly projectName: string;
+	readonly title: string;
+}
+
+export type ChatSwitcherRow = ChatSwitcherChatRow | ChatSwitcherCommandRow;
+
+export interface ChatSwitcherSection {
+	readonly label: string;
+	readonly rows: ReadonlyArray<ChatSwitcherRow>;
+}
+
+const RECENT_LIMIT = 5;
+const SEARCH_LIMIT = 20;
+const QUICK_ACTIONS: ReadonlySet<Command> = new Set([
+	"new-chat",
+	"open-project",
+	"toggle-terminal",
+]);
+
+const recencyOf = ({ chat }: ChatSwitcherChatRow): number =>
+	(chat.lastMessageAt ?? chat.updatedAt ?? chat.createdAt).getTime();
+
+/** Keep the landing view small without excluding older chats from search. */
+export function chatSwitcherSections(
+	chats: ReadonlyArray<ChatSwitcherChatRow>,
+	query: string,
+): ReadonlyArray<ChatSwitcherSection> {
+	const commandQuery = commandSearchQuery(query);
+	if (commandQuery !== null) {
+		return [{ label: "Commands", rows: commandRowsForQuery(query) }];
+	}
+	const availableChats = chats.filter((row) => row.chat.archivedAt === null);
+	const search = query.trim();
+	if (search.length > 0) {
+		return [
+			{
+				label: "Chats",
+				rows: fuzzysort
+					.go(search, availableChats, {
+						keys: ["title", "projectName"],
+						threshold: 0.3,
+						limit: SEARCH_LIMIT,
+					})
+					.map((result) => result.obj),
+			},
+			{ label: "Commands", rows: commandRowsForQuery(`>${search}`) },
+		];
+	}
+
+	const commands = commandRowsForQuery(">");
+	return [
+		{
+			label: "Recent chats",
+			rows: availableChats
+				.sort((a, b) => recencyOf(b) - recencyOf(a))
+				.slice(0, RECENT_LIMIT),
+		},
+		{
+			label: "Quick actions",
+			rows: commands.filter((row) => QUICK_ACTIONS.has(row.command)),
+		},
+		{
+			label: "Settings",
+			rows: commands.filter((row) => row.command === "settings"),
+		},
+	];
+}

--- a/apps/renderer/src/lib/commands.ts
+++ b/apps/renderer/src/lib/commands.ts
@@ -184,6 +184,7 @@ function stepPanel(delta: 1 | -1): void {
  * anything — it just fires effects.
  */
 const HANDLERS: Record<Command, () => void> = {
+	"search-files": () => useUiStore.getState().setFileSearchOpen(true),
 	"new-chat": () => {
 		const selectedChatId = useChatsStore.getState().selectedChatId;
 		const cloudProjectId =
@@ -297,6 +298,7 @@ export function dispatchCommand(command: Command): void {
  * would (a) submit twice and (b) preventDefault on the native typing event.
  */
 export const APPLICATION_COMMANDS: ReadonlySet<Command> = new Set<Command>([
+	"search-files",
 	"new-chat",
 	"open-project",
 	"settings",

--- a/apps/renderer/src/lib/default-keybindings.ts
+++ b/apps/renderer/src/lib/default-keybindings.ts
@@ -28,6 +28,11 @@ export const COMMAND_META: Record<Command, CommandMeta> = {
 		description: "Open or close the settings page",
 		group: "Application",
 	},
+	"search-files": {
+		label: "Search files",
+		description: "Find and open a file in the current project or worktree",
+		group: "Application",
+	},
 	"close-tab": {
 		label: "Close tab",
 		description: "Close the active chat tab",
@@ -233,6 +238,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
 	{ key: "ctrl+`", command: "focus-next-pane" },
 	{ key: "ctrl+shift+`", command: "focus-prev-pane" },
 	{ key: "mod+k", command: "open-chat-switcher" },
+	{ key: "mod+p", command: "search-files" },
 	{ key: "enter", command: "composer.submit" },
 	{ key: "shift+enter", command: "composer.newline" },
 	{ key: "mod+enter", command: "composer.forceSubmit" },

--- a/apps/renderer/src/lib/file-search.ts
+++ b/apps/renderer/src/lib/file-search.ts
@@ -1,0 +1,67 @@
+import type { ExecutionRef } from "@zuse/client-runtime/resource-ref";
+import {
+	deriveSurfacePhase,
+	type ResourceView,
+} from "@zuse/client-runtime/resource-state";
+import type { FolderId } from "@zuse/contracts";
+import fuzzysort from "fuzzysort";
+import type { useUiStore } from "../store/ui.ts";
+
+export function fileSearchFeedback(
+	view: ResourceView<{ readonly truncated: boolean }>,
+): { emptyMessage?: string; notice?: string } {
+	const phase = deriveSurfacePhase(view);
+	const unavailable =
+		phase === "error" ||
+		phase === "blocked-auth" ||
+		phase === "update-required" ||
+		phase === "offline-stale";
+	return {
+		emptyMessage: unavailable
+			? "Project files are unavailable. Check the workspace connection and try again."
+			: view.data === null
+				? "Loading project files…"
+				: undefined,
+		notice:
+			unavailable && view.data !== null
+				? "Connection interrupted. Showing cached files."
+				: view.data?.truncated
+					? "This project’s file list is partial. Some files may not appear."
+					: undefined,
+	};
+}
+
+export function searchableFiles(paths: ReadonlyArray<string>): string[] {
+	return paths
+		.filter((path) => !path.endsWith("/"))
+		.sort((a, b) => a.localeCompare(b));
+}
+
+export function fileSearchResults(
+	files: ReadonlyArray<string>,
+	query: string,
+): ReadonlyArray<string> {
+	const search = query.trim();
+	return search.length === 0
+		? files.slice(0, 100)
+		: fuzzysort
+				.go(search, files, { limit: 100, threshold: 0.4 })
+				.map((result) => result.target);
+}
+
+/** Preserve the execution environment and worktree when opening a match. */
+export function searchedFileTarget(
+	ref: ExecutionRef,
+	projectId: FolderId,
+	path: string,
+): Parameters<ReturnType<typeof useUiStore.getState>["openFileInTab"]>[0] {
+	return {
+		kind: "text",
+		environmentId: ref.environmentId,
+		folderId: ref.folderId,
+		projectId,
+		worktreeId: ref.worktreeId,
+		path,
+		name: path.split("/").at(-1) ?? path,
+	};
+}

--- a/apps/renderer/src/lib/file-tree-resource-hooks.ts
+++ b/apps/renderer/src/lib/file-tree-resource-hooks.ts
@@ -1,0 +1,31 @@
+import type { ExecutionRef } from "@zuse/client-runtime/resource-ref";
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import {
+	fileTreeResourceKey,
+	fileTreeResourceSnapshot,
+	retainFileTreeResource,
+	subscribeFileTreeResource,
+} from "./file-tree-client-bus.ts";
+
+/** File tree and file search retain the same qualified, live resource. */
+export function useFileTreeResource({
+	environmentId,
+	folderId,
+	worktreeId,
+	rootPath,
+}: ExecutionRef) {
+	const key = useMemo(
+		() =>
+			fileTreeResourceKey({ environmentId, folderId, worktreeId, rootPath }),
+		[environmentId, folderId, rootPath, worktreeId],
+	);
+	useEffect(() => {
+		const retained = retainFileTreeResource(key);
+		return () => retained.lease.release();
+	}, [key]);
+	return useSyncExternalStore(
+		(listener) => subscribeFileTreeResource(key, listener),
+		() => fileTreeResourceSnapshot(key),
+		() => fileTreeResourceSnapshot(key),
+	);
+}

--- a/apps/renderer/src/lib/settings-navigation.ts
+++ b/apps/renderer/src/lib/settings-navigation.ts
@@ -1,0 +1,108 @@
+import type { IconSvgElement } from "@hugeicons/react";
+import {
+	BrowserIcon,
+	ConnectIcon,
+	DocumentAttachmentIcon,
+	KeyboardIcon,
+	PackageIcon,
+	PlugSocketIcon,
+	Settings01Icon,
+	SmartPhone01Icon,
+	TaskDone01Icon,
+	TestTubeIcon,
+} from "@zuse/icons/solid-rounded";
+import type { SettingsSection } from "../store/ui.ts";
+import { cloudWorkspaceBetaAvailable } from "./cloud-machines-availability.ts";
+
+export type SettingsNavigationItem = {
+	readonly id: string;
+	readonly label: string;
+	readonly Icon: IconSvgElement;
+	readonly section: SettingsSection;
+};
+
+const TOP_RAIL: ReadonlyArray<SettingsNavigationItem> = [
+	{
+		id: "general",
+		label: "General",
+		Icon: Settings01Icon,
+		section: { kind: "general" },
+	},
+	{
+		id: "providers",
+		label: "Providers",
+		Icon: PackageIcon,
+		section: { kind: "providers" },
+	},
+	{
+		id: "defaults",
+		label: "Default models",
+		Icon: TaskDone01Icon,
+		section: { kind: "defaults" },
+	},
+	{
+		id: "mcp",
+		label: "MCP Servers",
+		Icon: PlugSocketIcon,
+		section: { kind: "mcp" },
+	},
+	{
+		id: "integrations",
+		label: "Integrations",
+		Icon: ConnectIcon,
+		section: { kind: "integrations" },
+	},
+	{
+		id: "devices",
+		label: "Remote access",
+		Icon: SmartPhone01Icon,
+		section: { kind: "devices" },
+	},
+	{
+		id: "machines",
+		label: "Cloud workspaces · Beta",
+		Icon: ConnectIcon,
+		section: { kind: "machines" },
+	},
+	{
+		id: "browser",
+		label: "Browser",
+		Icon: BrowserIcon,
+		section: { kind: "browser" },
+	},
+	{
+		id: "pokedex",
+		label: "Pokedex",
+		Icon: TaskDone01Icon,
+		section: { kind: "pokedex" },
+	},
+	{
+		id: "shortcuts",
+		label: "Keyboard shortcuts",
+		Icon: KeyboardIcon,
+		section: { kind: "shortcuts" },
+	},
+	{
+		id: "diagnostics",
+		label: "Diagnostics",
+		Icon: DocumentAttachmentIcon,
+		section: { kind: "diagnostics" },
+	},
+	// Dev-only visual playground (accent swatches + workflow chip/button
+	// showcase). Filtered out of production bundles below.
+	{
+		id: "developer",
+		label: "Developer",
+		Icon: TestTubeIcon,
+		section: { kind: "developer" },
+	},
+];
+
+const CLOUD_MACHINES_AVAILABLE = cloudWorkspaceBetaAvailable();
+
+export const SETTINGS_NAVIGATION: ReadonlyArray<SettingsNavigationItem> =
+	TOP_RAIL.filter(
+		(item) =>
+			(item.id !== "developer" || import.meta.env.DEV) &&
+			(item.id !== "machines" || CLOUD_MACHINES_AVAILABLE),
+	);

--- a/apps/renderer/src/lib/shortcuts.ts
+++ b/apps/renderer/src/lib/shortcuts.ts
@@ -1,5 +1,4 @@
-import { formatKeyForDisplay } from "@zuse/contracts";
-import type { MenuAction } from "./bridge";
+import { type Command, formatKeyForDisplay } from "@zuse/contracts";
 import { isMacHost } from "./host-platform";
 import { keybindingsSnapshot } from "./keybindings-client-bus.ts";
 
@@ -15,7 +14,7 @@ const IS_MAC = isMacHost();
  * `<TooltipShortcut shortcut={…}>`, and React expects a string. Wrapping
  * it in a hook would require every caller to subscribe.
  */
-export function formatShortcut(id: MenuAction): string {
+export function formatShortcut(id: Command): string {
 	const rules = keybindingsSnapshot().resolvedRules;
 	// Prefer an unconditional rule (matches menu accelerator semantics).
 	for (let i = rules.length - 1; i >= 0; i--) {

--- a/apps/renderer/src/store/ui.ts
+++ b/apps/renderer/src/store/ui.ts
@@ -188,6 +188,8 @@ type UiState = {
 	readonly view: View;
 	readonly setView: (view: View) => void;
 	readonly settingsSection: SettingsSection;
+	readonly fileSearchOpen: boolean;
+	readonly setFileSearchOpen: (open: boolean) => void;
 	readonly setSettingsSection: (section: SettingsSection) => void;
 	readonly activeMainTab: MainTab;
 	readonly usageScope: UsageScope;
@@ -435,6 +437,13 @@ export const useUiStore = create<UiState>((set, get) => ({
 	view: "chat",
 	setView: (view) => set({ view }),
 	settingsSection: { kind: "general" },
+	fileSearchOpen: false,
+	setFileSearchOpen: (fileSearchOpen) =>
+		set(
+			fileSearchOpen
+				? { fileSearchOpen, chatSwitcherOpen: false }
+				: { fileSearchOpen },
+		),
 	setSettingsSection: (section) => set({ settingsSection: section }),
 	activeMainTab: "chat",
 	usageScope: "global",
@@ -552,9 +561,18 @@ export const useUiStore = create<UiState>((set, get) => ({
 			persistRightPaneWidths(rightPaneLayoutByChat);
 			return { rightPaneLayoutByChat };
 		}),
-	setChatSwitcherOpen: (open) => set({ chatSwitcherOpen: open }),
+	setChatSwitcherOpen: (open) =>
+		set(
+			open
+				? { chatSwitcherOpen: open, fileSearchOpen: false }
+				: { chatSwitcherOpen: open },
+		),
 	toggleChatSwitcher: () =>
-		set((s) => ({ chatSwitcherOpen: !s.chatSwitcherOpen })),
+		set((s) =>
+			s.chatSwitcherOpen
+				? { chatSwitcherOpen: false }
+				: { chatSwitcherOpen: true, fileSearchOpen: false },
+		),
 	setFullScreen: (full) => set({ isFullScreen: full }),
 	setEnvironmentSummaryOpen: (open) => {
 		persistEnvironmentSummaryOpen(open);

--- a/apps/renderer/test/unit/chat-switcher-commands.test.ts
+++ b/apps/renderer/test/unit/chat-switcher-commands.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	commandRowsForQuery,
+	commandSearchQuery,
+} from "../../src/lib/chat-switcher-commands.ts";
+import { APPLICATION_COMMANDS } from "../../src/lib/commands.ts";
+import {
+	COMMAND_META,
+	COMMANDS_IN_ORDER,
+} from "../../src/lib/default-keybindings.ts";
+
+describe("chat switcher command mode", () => {
+	it("enters command mode only when the trimmed query starts with >", () => {
+		expect(commandSearchQuery("chat")).toBeNull();
+		expect(commandSearchQuery("chat > settings")).toBeNull();
+		expect(commandSearchQuery("  > settings ")).toBe("settings");
+	});
+
+	it("projects application commands in canonical order and excludes itself", () => {
+		const expected = COMMANDS_IN_ORDER.filter(
+			(command) =>
+				APPLICATION_COMMANDS.has(command) && command !== "open-chat-switcher",
+		);
+		const rows = commandRowsForQuery(">");
+
+		expect(rows.map((row) => row.command)).toEqual(expected);
+		expect(rows.map((row) => row.command)).not.toContain("open-chat-switcher");
+		expect(rows.map((row) => row.command)).not.toContain("composer.submit");
+		expect(rows.map((row) => row.command)).not.toContain("editor.save");
+	});
+
+	it("copies labels and descriptions from the shared command metadata", () => {
+		const row = commandRowsForQuery(">").find(
+			(candidate) => candidate.command === "new-chat",
+		);
+
+		expect(row).toMatchObject(COMMAND_META["new-chat"]);
+	});
+
+	it("searches command labels, descriptions, and groups", () => {
+		expect(commandRowsForQuery(">terminal")[0]?.command).toBe(
+			"toggle-terminal",
+		);
+		expect(
+			commandRowsForQuery(">pick folder").map((row) => row.command),
+		).toContain("open-project");
+		expect(commandRowsForQuery(">application").length).toBeGreaterThan(1);
+	});
+
+	it("returns no command rows in chat mode", () => {
+		expect(commandRowsForQuery("settings")).toEqual([]);
+	});
+});

--- a/apps/renderer/test/unit/chat-switcher-items.test.ts
+++ b/apps/renderer/test/unit/chat-switcher-items.test.ts
@@ -1,0 +1,107 @@
+import { Chat, ChatId, FolderId } from "@zuse/contracts";
+import { describe, expect, it } from "vitest";
+import {
+	type ChatSwitcherChatRow,
+	chatSwitcherSections,
+} from "../../src/lib/chat-switcher-items.ts";
+
+const chatRow = (
+	index: number,
+	overrides: Partial<Chat> = {},
+): ChatSwitcherChatRow => {
+	const chat = Chat.make({
+		id: ChatId.make(`chat-${index}`),
+		projectId: FolderId.make("project-1"),
+		title: `Conversation ${index}`,
+		titleProvenance: "manual",
+		worktreeId: null,
+		activeSessionId: null,
+		originSessionId: null,
+		archivedAt: null,
+		lastMessageAt: null,
+		lastReadAt: null,
+		createdAt: new Date(index),
+		updatedAt: new Date(index),
+		...overrides,
+	});
+	return { kind: "chat", chat, title: chat.title, projectName: "Workspace" };
+};
+
+describe("quick open sections", () => {
+	it("shows only the five most recent chats without mutating its input", () => {
+		const chats = Array.from({ length: 12 }, (_, index) => chatRow(index));
+		const originalOrder = [...chats];
+		expect(chatSwitcherSections(chats, "")[0]?.rows).toEqual(
+			chats.slice(7).reverse(),
+		);
+		expect(chats).toEqual(originalOrder);
+	});
+
+	it("uses last-message activity before update time and excludes archived chats", () => {
+		const active = chatRow(1, { lastMessageAt: new Date(100) });
+		const updated = chatRow(5);
+		const archived = chatRow(200, { archivedAt: new Date() });
+		expect(
+			chatSwitcherSections([updated, archived, active], "")[0]?.rows,
+		).toEqual([active, updated]);
+		expect(chatSwitcherSections([archived], "Conversation")[0]?.rows).toEqual(
+			[],
+		);
+	});
+
+	it("finds older chats outside the recent limit and searches project names", () => {
+		const old = chatRow(0, { title: "Release checklist" });
+		const chats = [
+			old,
+			...Array.from({ length: 10 }, (_, index) => chatRow(index + 1)),
+		];
+		expect(chatSwitcherSections(chats, "Release")[0]?.rows).toEqual([old]);
+		expect(chatSwitcherSections([old], "Workspace")[0]?.rows).toEqual([old]);
+	});
+
+	it("shows both matching chats and commands without requiring a prefix", () => {
+		const chat = chatRow(0, { title: "Terminal fixes" });
+		const sections = chatSwitcherSections([chat], "terminal");
+		expect(sections[0]?.rows).toEqual([chat]);
+		expect(sections[1]?.rows[0]).toMatchObject({ command: "toggle-terminal" });
+	});
+
+	it("keeps the explicit command-only mode", () => {
+		const sections = chatSwitcherSections(
+			[chatRow(0, { title: "Settings" })],
+			" > settings ",
+		);
+		expect(sections).toHaveLength(1);
+		expect(sections[0]?.rows[0]).toMatchObject({
+			kind: "command",
+			command: "settings",
+		});
+		expect(sections[0]?.rows.every((row) => row.kind === "command")).toBe(true);
+	});
+
+	it("offers real quick actions and settings even with no chats", () => {
+		const sections = chatSwitcherSections([], "   ");
+		expect(sections.map((section) => section.label)).toEqual([
+			"Recent chats",
+			"Quick actions",
+			"Settings",
+		]);
+		expect(
+			sections[1]?.rows.map((row) => row.kind === "command" && row.command),
+		).toEqual(["new-chat", "open-project", "toggle-terminal"]);
+		expect(sections[2]?.rows).toHaveLength(1);
+		expect(sections[2]?.rows[0]).toMatchObject({ command: "settings" });
+	});
+
+	it("bounds chat search results and returns no matches for an unknown query", () => {
+		const chats = Array.from({ length: 100 }, (_, index) => chatRow(index));
+		expect(chatSwitcherSections(chats, "Conversation")[0]?.rows).toHaveLength(
+			20,
+		);
+		expect(
+			chatSwitcherSections(chats, "zzzzzzzz").flatMap(
+				(section) => section.rows,
+			),
+		).toEqual([]);
+	});
+});

--- a/apps/renderer/test/unit/chat-switcher-items.test.ts
+++ b/apps/renderer/test/unit/chat-switcher-items.test.ts
@@ -4,6 +4,7 @@ import {
 	type ChatSwitcherChatRow,
 	chatSwitcherSections,
 } from "../../src/lib/chat-switcher-items.ts";
+import { SETTINGS_NAVIGATION } from "../../src/lib/settings-navigation.ts";
 
 const chatRow = (
 	index: number,
@@ -85,12 +86,36 @@ describe("quick open sections", () => {
 			"Recent chats",
 			"Quick actions",
 			"Settings",
+			"Workspace",
+			"Navigation",
 		]);
 		expect(
 			sections[1]?.rows.map((row) => row.kind === "command" && row.command),
-		).toEqual(["new-chat", "open-project", "toggle-terminal"]);
-		expect(sections[2]?.rows).toHaveLength(1);
-		expect(sections[2]?.rows[0]).toMatchObject({ command: "settings" });
+		).toEqual([
+			"new-chat",
+			"open-project",
+			"search-files",
+			"toggle-terminal",
+			"new-tab",
+		]);
+		expect(
+			sections[2]?.rows.map((row) => row.kind === "settings" && row.section),
+		).toEqual(SETTINGS_NAVIGATION.map((item) => item.section));
+		expect(sections[3]?.rows.length).toBeGreaterThan(1);
+		expect(sections[4]?.rows.length).toBeGreaterThan(1);
+	});
+
+	it("finds settings destinations without loading the settings page", () => {
+		expect(
+			chatSwitcherSections([], "Keyboard shortcuts").flatMap(
+				(section) => section.rows,
+			),
+		).toContainEqual(
+			expect.objectContaining({
+				kind: "settings",
+				section: { kind: "shortcuts" },
+			}),
+		);
 	});
 
 	it("bounds chat search results and returns no matches for an unknown query", () => {

--- a/apps/renderer/test/unit/file-search-icons.test.tsx
+++ b/apps/renderer/test/unit/file-search-icons.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { FileSearchDialog } from "../../src/components/file-search.tsx";
+import type { CommandPaletteGroup } from "../../src/components/ui/command-palette.tsx";
+
+// Render the actual result icons without the modal's browser-only portal.
+vi.mock("../../src/components/ui/command-palette.tsx", () => ({
+	CommandPaletteDialog: ({
+		groups,
+	}: {
+		groups: ReadonlyArray<CommandPaletteGroup<string>>;
+	}) => (
+		<div>
+			{groups.flatMap((group) =>
+				group.items.map((item) => <span key={item.id}>{item.icon}</span>),
+			)}
+		</div>
+	),
+}));
+
+describe("file search result icons", () => {
+	it.each([
+		["README.md", "markdown"],
+		["src/app.tsx", "react"],
+		["src/index.ts", "typescript"],
+		["Dockerfile", "docker"],
+	] as const)("renders the shared file-type icon for %s", (path, token) => {
+		const markup = renderToStaticMarkup(
+			<FileSearchDialog
+				files={[path]}
+				onClose={() => {}}
+				onSelect={() => {}}
+			/>,
+		);
+		expect(markup).toContain(`data-file-icon-token="${token}"`);
+		expect(markup).toContain('aria-hidden="true"');
+	});
+});

--- a/apps/renderer/test/unit/file-search.test.ts
+++ b/apps/renderer/test/unit/file-search.test.ts
@@ -1,0 +1,121 @@
+import { emptyResourceView } from "@zuse/client-runtime/resource-state";
+import { EnvironmentId, FolderId, WorktreeId } from "@zuse/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	APPLICATION_COMMANDS,
+	dispatchCommand,
+} from "../../src/lib/commands.ts";
+import { DEFAULT_KEYBINDINGS } from "../../src/lib/default-keybindings.ts";
+import {
+	fileSearchFeedback,
+	fileSearchResults,
+	searchableFiles,
+	searchedFileTarget,
+} from "../../src/lib/file-search.ts";
+import { useUiStore } from "../../src/store/ui.ts";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	useUiStore.getState().setFileSearchOpen(false);
+});
+
+describe("project file search", () => {
+	it.each([
+		"failed",
+		"offline",
+		"revoked",
+		"blocked-auth",
+		"update-required",
+	] as const)("does not show a perpetual loading state for %s connections", (connection) => {
+		expect(
+			fileSearchFeedback(emptyResourceView(connection)).emptyMessage,
+		).toContain("unavailable");
+	});
+	it("distinguishes loading, cached disconnection, and partial results", () => {
+		const view = emptyResourceView<{ truncated: boolean }>("connecting");
+		expect(fileSearchFeedback(view).emptyMessage).toContain("Loading");
+		expect(
+			fileSearchFeedback({
+				...view,
+				connection: "offline",
+				data: { truncated: false },
+			}).notice,
+		).toContain("cached");
+		expect(
+			fileSearchFeedback({
+				...view,
+				connection: "connected",
+				sync: "live",
+				data: { truncated: true },
+			}).notice,
+		).toContain("partial");
+	});
+	it("keeps only one search modal open when switching with shortcuts", () => {
+		const ui = useUiStore.getState();
+		ui.setChatSwitcherOpen(true);
+		ui.setFileSearchOpen(true);
+		expect(useUiStore.getState()).toMatchObject({
+			fileSearchOpen: true,
+			chatSwitcherOpen: false,
+		});
+		ui.toggleChatSwitcher();
+		expect(useUiStore.getState()).toMatchObject({
+			fileSearchOpen: false,
+			chatSwitcherOpen: true,
+		});
+		ui.setChatSwitcherOpen(false);
+	});
+	it("excludes directories and sorts without mutating the resource snapshot", () => {
+		const paths = ["src/", "src/z.ts", "README.md", "src/a.ts"];
+		expect(searchableFiles(paths)).toEqual([
+			"README.md",
+			"src/a.ts",
+			"src/z.ts",
+		]);
+		expect(paths).toEqual(["src/", "src/z.ts", "README.md", "src/a.ts"]);
+	});
+	it("bounds empty and matching results, but can find a file outside the initial window", () => {
+		const files = Array.from(
+			{ length: 500 },
+			(_, index) => `src/component-${index}.tsx`,
+		);
+		files.push("src/deep/unique-target.ts");
+		expect(fileSearchResults(files, " ")).toHaveLength(100);
+		expect(fileSearchResults(files, "component")).toHaveLength(100);
+		expect(fileSearchResults(files, "unique-target")).toEqual([
+			"src/deep/unique-target.ts",
+		]);
+		expect(fileSearchResults(files, "zzzzzzzz")).toEqual([]);
+	});
+	it("keeps cloud checkout, logical project, and worktree identity when opening", () => {
+		const ref = {
+			environmentId: EnvironmentId.make("cloud-1"),
+			folderId: FolderId.make("checkout-1"),
+			worktreeId: WorktreeId.make("worktree-1"),
+			rootPath: "/worktree",
+		};
+		expect(
+			searchedFileTarget(ref, FolderId.make("local-project"), "src/index.ts"),
+		).toEqual({
+			kind: "text",
+			environmentId: ref.environmentId,
+			folderId: ref.folderId,
+			projectId: "local-project",
+			worktreeId: ref.worktreeId,
+			path: "src/index.ts",
+			name: "index.ts",
+		});
+	});
+	it("uses the shared shortcut registry and opens on dispatch without a mounted file tree", () => {
+		expect(APPLICATION_COMMANDS.has("search-files")).toBe(true);
+		expect(DEFAULT_KEYBINDINGS).toContainEqual({
+			key: "mod+p",
+			command: "search-files",
+		});
+		vi.stubGlobal("document", { body: { dataset: {} } });
+		dispatchCommand("search-files");
+		expect(useUiStore.getState().fileSearchOpen).toBe(true);
+		useUiStore.getState().setFileSearchOpen(false);
+		expect(useUiStore.getState().fileSearchOpen).toBe(false);
+	});
+});

--- a/apps/server/src/provider/layers/provider-service.ts
+++ b/apps/server/src/provider/layers/provider-service.ts
@@ -661,6 +661,9 @@ export const ProviderServiceLive = Layer.effect(
 							mcpProxyCommand ?? process.execPath,
 							orchestrationTools,
 							resumeCursor,
+							() => {
+								registry.invalidateIfCurrent(sessionId, generation);
+							},
 						).pipe(Effect.provideService(AttachmentService, attachmentService));
 					}
 					const handle = yield* makeTurnScopedSessionHandle(

--- a/apps/server/src/provider/provider-session-registry.ts
+++ b/apps/server/src/provider/provider-session-registry.ts
@@ -16,6 +16,10 @@ export interface ProviderSessionRegistry<SessionId, Entry> {
 		entry: Entry,
 	) => boolean;
 	readonly invalidate: (sessionId: SessionId) => Entry | undefined;
+	readonly invalidateIfCurrent: (
+		sessionId: SessionId,
+		generation: number,
+	) => Entry | undefined;
 }
 
 export const makeProviderSessionRegistry = <
@@ -24,6 +28,12 @@ export const makeProviderSessionRegistry = <
 >(): ProviderSessionRegistry<SessionId, Entry> => {
 	const sessions = new Map<SessionId, Entry>();
 	const generations = new Map<SessionId, number>();
+	const invalidate = (sessionId: SessionId): Entry | undefined => {
+		const entry = sessions.get(sessionId);
+		sessions.delete(sessionId);
+		generations.set(sessionId, (generations.get(sessionId) ?? 0) + 1);
+		return entry;
+	};
 	return {
 		lookup: (sessionId) => sessions.get(sessionId),
 		currentGeneration: (sessionId) => generations.get(sessionId),
@@ -39,11 +49,10 @@ export const makeProviderSessionRegistry = <
 			sessions.set(sessionId, entry);
 			return true;
 		},
-		invalidate: (sessionId) => {
-			const entry = sessions.get(sessionId);
-			sessions.delete(sessionId);
-			generations.set(sessionId, (generations.get(sessionId) ?? 0) + 1);
-			return entry;
-		},
+		invalidate,
+		invalidateIfCurrent: (sessionId, generation) =>
+			generations.get(sessionId) === generation
+				? invalidate(sessionId)
+				: undefined,
 	};
 };

--- a/apps/server/test/unit/provider-session-registry.test.ts
+++ b/apps/server/test/unit/provider-session-registry.test.ts
@@ -14,12 +14,55 @@ describe("provider session registry", () => {
 		expect(registry.lookup("session-1")).toBe("grok");
 	});
 
-	it("invalidates an in-flight generation even without a published handle", () => {
+	it.each([
+		"explicit",
+		"unexpected",
+	] as const)("invalidates an in-flight generation on %s stop", (kind) => {
 		const registry = makeProviderSessionRegistry<string, string>();
 		const generation = registry.begin("session-1");
 
-		expect(registry.invalidate("session-1")).toBeUndefined();
+		expect(
+			kind === "explicit"
+				? registry.invalidate("session-1")
+				: registry.invalidateIfCurrent("session-1", generation),
+		).toBeUndefined();
 		expect(registry.publish("session-1", generation, "late")).toBe(false);
 		expect(registry.lookup("session-1")).toBeUndefined();
+	});
+
+	it("removes the current crashed handle and permits a later generation", () => {
+		const registry = makeProviderSessionRegistry<string, string>();
+		const crashedGeneration = registry.begin("session-1");
+		expect(registry.publish("session-1", crashedGeneration, "crashed")).toBe(
+			true,
+		);
+
+		expect(registry.invalidateIfCurrent("session-1", crashedGeneration)).toBe(
+			"crashed",
+		);
+		expect(registry.lookup("session-1")).toBeUndefined();
+
+		const restartedGeneration = registry.begin("session-1");
+		expect(
+			registry.publish("session-1", restartedGeneration, "restarted"),
+		).toBe(true);
+		expect(registry.lookup("session-1")).toBe("restarted");
+	});
+
+	it("does not let a stale process exit remove its replacement", () => {
+		const registry = makeProviderSessionRegistry<string, string>();
+		const staleGeneration = registry.begin("session-1");
+		expect(registry.publish("session-1", staleGeneration, "stale")).toBe(true);
+
+		registry.invalidate("session-1");
+		const replacementGeneration = registry.begin("session-1");
+		expect(
+			registry.publish("session-1", replacementGeneration, "replacement"),
+		).toBe(true);
+
+		expect(
+			registry.invalidateIfCurrent("session-1", staleGeneration),
+		).toBeUndefined();
+		expect(registry.lookup("session-1")).toBe("replacement");
 	});
 });

--- a/packages/agents/src/drivers/codex-app-server-client.ts
+++ b/packages/agents/src/drivers/codex-app-server-client.ts
@@ -19,6 +19,9 @@ type ServerRequestHandler = (
 ) => void;
 
 type NotificationHandler = (notification: ServerNotification) => void;
+type UnexpectedTerminationHandler = (error: Error) => void;
+
+const STDERR_TAIL_LIMIT_BYTES = 4 * 1024;
 
 export interface CodexChatgptAuthTokens {
 	readonly accessToken: string;
@@ -159,6 +162,7 @@ export class CodexAppServerClient {
 	private readonly child: ChildProcessWithoutNullStreams;
 	private readonly rl: readline.Interface;
 	private closed = false;
+	private stderrTail = Buffer.alloc(0);
 
 	initializeResponse: InitializeResponse;
 
@@ -168,6 +172,7 @@ export class CodexAppServerClient {
 		initializeResponse: InitializeResponse,
 		readonly onNotification: NotificationHandler,
 		readonly onServerRequest: ServerRequestHandler,
+		readonly onUnexpectedTermination?: UnexpectedTerminationHandler,
 	) {
 		this.child = child;
 		this.rl = rl;
@@ -185,6 +190,7 @@ export class CodexAppServerClient {
 		readonly externalAuthProvider?: CodexExternalAuthProvider;
 		/** Session identity used only to resume a proven auth-blocked consumer. */
 		readonly externalAuthConsumerId?: string;
+		readonly onUnexpectedTermination?: UnexpectedTerminationHandler;
 	}): Promise<CodexAppServerClient> {
 		const externalAuthProvider =
 			options.externalAuthProvider ?? defaultExternalAuthProvider;
@@ -251,9 +257,11 @@ export class CodexAppServerClient {
 			},
 			options.onNotification,
 			handleServerRequest,
+			options.onUnexpectedTermination,
 		);
 		rl.on("line", (line) => bootstrap.handleLine(line));
 		child.stderr.on("data", (chunk) => {
+			bootstrap.appendStderr(String(chunk));
 			const text = String(chunk).trim();
 			if (text.length === 0) return;
 			if (options.onStderr !== undefined) options.onStderr(text);
@@ -264,18 +272,13 @@ export class CodexAppServerClient {
 		// that crashes the whole process. Surface it as a rejection of every
 		// pending request — including the `initialize` we're about to await —
 		// so callers see a normal Effect failure they already know how to catch.
-		child.once("error", (err) => {
-			bootstrap.closed = true;
-			for (const p of bootstrap.pending.values()) p.reject(err as Error);
-			bootstrap.pending.clear();
-		});
-		child.once("exit", (code, signal) => {
-			bootstrap.closed = true;
-			const reason = new Error(
-				`Codex app-server exited with ${signal ?? `code ${code ?? 0}`}`,
+		child.once("error", (err) => bootstrap.handleUnexpectedTermination(err));
+		child.once("close", (code, signal) => {
+			bootstrap.handleUnexpectedTermination(
+				new Error(
+					`Codex app-server exited with ${signal ?? `code ${code ?? 0}`}`,
+				),
 			);
-			for (const p of bootstrap.pending.values()) p.reject(reason);
-			bootstrap.pending.clear();
 		});
 
 		let timer: NodeJS.Timeout | undefined;
@@ -369,7 +372,54 @@ export class CodexAppServerClient {
 		if (this.closed) return;
 		this.closed = true;
 		this.rl.close();
+		this.rejectPending(new Error("Codex app-server is closed"));
 		this.child.kill();
+	}
+
+	private appendStderr(text: string): void {
+		const incoming = Buffer.from(text, "utf8");
+		if (incoming.length >= STDERR_TAIL_LIMIT_BYTES) {
+			this.stderrTail = Buffer.from(
+				incoming.subarray(incoming.length - STDERR_TAIL_LIMIT_BYTES),
+			);
+			return;
+		}
+		const retained = this.stderrTail.subarray(
+			Math.max(
+				0,
+				this.stderrTail.length - (STDERR_TAIL_LIMIT_BYTES - incoming.length),
+			),
+		);
+		this.stderrTail = Buffer.concat([retained, incoming]);
+	}
+
+	private handleUnexpectedTermination(error: Error): void {
+		// `error` and `close` may both fire for one failed child. The first signal
+		// owns termination; an explicit close sets `closed` before killing the child
+		// and therefore remains intentionally quiet.
+		if (this.closed) return;
+		this.closed = true;
+		this.rl.close();
+		const stderr = this.stderrTail.toString("utf8").trim();
+		const reason =
+			stderr.length === 0
+				? error
+				: new Error(`${error.message}\nCodex stderr (tail):\n${stderr}`, {
+						cause: error,
+					});
+		this.rejectPending(reason);
+		try {
+			this.onUnexpectedTermination?.(reason);
+		} catch (cause) {
+			reportCodexStderr(
+				`unexpected termination handler failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+			);
+		}
+	}
+
+	private rejectPending(reason: Error): void {
+		for (const pending of this.pending.values()) pending.reject(reason);
+		this.pending.clear();
 	}
 
 	private handleLine(line: string): void {

--- a/packages/agents/src/drivers/codex.ts
+++ b/packages/agents/src/drivers/codex.ts
@@ -1396,6 +1396,7 @@ export const startCodexSession = (
 	mcpProxyCommand: string,
 	orchestrationTools: OrchestrationSessionTools | null = null,
 	resumeCursor: string | null = null,
+	onUnexpectedTermination?: (error: Error) => void,
 ): Effect.Effect<
 	CodexSessionHandle,
 	AgentSessionStartError,
@@ -1505,6 +1506,28 @@ export const startCodexSession = (
 			endpoint: mcpGatewaySession.endpoint,
 			token: mcpGatewaySession.token,
 		});
+		const handleUnexpectedTermination = (error: Error): void => {
+			if (closed) return;
+			// Publish the concrete transport error before ending the stream. The shared
+			// turn protocol scopes it to the active durable turn and synthesizes its
+			// terminal; when idle, ending the stream still retires the dead handle.
+			emit({ _tag: "Error", message: error.message });
+			closed = true;
+			for (const waiter of questionWaiters.values()) waiter.resolve([]);
+			questionWaiters.clear();
+			for (const resolve of gatewayQuestionWaiters.values()) resolve(null);
+			gatewayQuestionWaiters.clear();
+			void mcpGatewaySession.close();
+			void stdioMcpFallback.close();
+			Queue.endUnsafe(events);
+			try {
+				onUnexpectedTermination?.(error);
+			} catch (cause) {
+				reportCodexStderr(
+					`unexpected termination callback failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+				);
+			}
+		};
 
 		let app = yield* Effect.tryPromise({
 			try: () =>
@@ -1533,6 +1556,7 @@ export const startCodexSession = (
 								respond(defaultServerRequestResponse(request));
 							});
 					},
+					onUnexpectedTermination: handleUnexpectedTermination,
 				}),
 			catch: (cause) =>
 				new AgentSessionStartError({
@@ -1600,6 +1624,7 @@ export const startCodexSession = (
 					await expectCodexMcpServer(app);
 					console.info(`[mcp-gateway] session ${sessionId} connected via http`);
 				} catch (httpCause) {
+					if (closed) throw httpCause;
 					console.warn(
 						`[mcp-gateway] session ${sessionId} HTTP setup failed; retrying with stdio compatibility transport`,
 						httpCause,
@@ -1636,6 +1661,7 @@ export const startCodexSession = (
 									respond(defaultServerRequestResponse(request));
 								});
 						},
+						onUnexpectedTermination: handleUnexpectedTermination,
 					});
 					await expectCodexMcpServer(app);
 					console.info(

--- a/packages/agents/test/unit/drivers/codex-app-server-client.test.ts
+++ b/packages/agents/test/unit/drivers/codex-app-server-client.test.ts
@@ -290,3 +290,96 @@ lines.on("line", (line) => {
 		}
 	});
 });
+
+describe("Codex app-server process lifecycle", () => {
+	it("reports one unexpected exit with a bounded stderr tail", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-app-server-exit-"));
+		const executable = join(directory, "fake-app-server.mjs");
+		const terminations: Array<Error> = [];
+		let client: CodexAppServerClient | null = null;
+		try {
+			writeFileSync(
+				executable,
+				`#!/usr/bin/env node
+import readline from "node:readline";
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+	const request = JSON.parse(line);
+	if (request.method === "initialize") {
+		process.stdout.write(JSON.stringify({
+			id: request.id,
+			result: { userAgent: "test", codexHome: "", platformFamily: "", platformOs: "" },
+		}) + "\\n");
+		return;
+	}
+	process.stderr.write("discarded-prefix:" + "x".repeat(5000) + ":fatal-tail-marker\\n", () => {
+		process.exit(17);
+	});
+});
+`,
+				{ mode: 0o755 },
+			);
+
+			client = await CodexAppServerClient.start({
+				codexPath: executable,
+				startupTimeoutMs: 2_000,
+				onStderr: () => {},
+				onNotification: () => {},
+				onServerRequest: () => {},
+				onUnexpectedTermination: (error) => terminations.push(error),
+			});
+			await expect(client.request("model/list", {})).rejects.toThrow(
+				/Codex app-server exited with code 17[\s\S]*fatal-tail-marker/,
+			);
+			expect(terminations).toHaveLength(1);
+			expect(terminations[0]?.message).not.toContain("discarded-prefix");
+			expect(
+				Buffer.byteLength(terminations[0]?.message ?? "", "utf8"),
+			).toBeLessThan(4_300);
+		} finally {
+			client?.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps explicit close silent", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-app-server-close-"));
+		const executable = join(directory, "fake-app-server.mjs");
+		const terminations: Array<Error> = [];
+		let client: CodexAppServerClient | null = null;
+		try {
+			writeFileSync(
+				executable,
+				`#!/usr/bin/env node
+import readline from "node:readline";
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+	const request = JSON.parse(line);
+	if (request.method !== "initialize") return;
+	process.stdout.write(JSON.stringify({
+		id: request.id,
+		result: { userAgent: "test", codexHome: "", platformFamily: "", platformOs: "" },
+	}) + "\\n");
+});
+`,
+				{ mode: 0o755 },
+			);
+
+			client = await CodexAppServerClient.start({
+				codexPath: executable,
+				startupTimeoutMs: 2_000,
+				onNotification: () => {},
+				onServerRequest: () => {},
+				onUnexpectedTermination: (error) => terminations.push(error),
+			});
+			const pending = client.request("model/list", {});
+			client.close();
+			await expect(pending).rejects.toThrow("Codex app-server is closed");
+			await new Promise((resolve) => setTimeout(resolve, 30));
+			expect(terminations).toEqual([]);
+		} finally {
+			client?.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/agents/test/unit/drivers/codex-session-lifecycle.test.ts
+++ b/packages/agents/test/unit/drivers/codex-session-lifecycle.test.ts
@@ -10,9 +10,11 @@ import {
 	CodexAppServerRequestError,
 } from "@zuse/agents/drivers/codex-app-server-client";
 import { AttachmentService } from "@zuse/agents/kernel/attachment-service";
+import { makeTurnScopedSessionHandle } from "@zuse/agents/kernel/turn-protocol";
 import type {
 	AgentEvent,
 	AgentSessionId,
+	AgentTurnId,
 	FolderId,
 	StartSessionInput,
 } from "@zuse/contracts";
@@ -41,17 +43,29 @@ const input = (
 const installAppServer = (
 	missingResume: boolean,
 	initialMissingMcpInventories = 0,
+	terminateOnMcpInventory = false,
 ) => {
 	let mcpInventoryReads = 0;
+	let startupTerminated = false;
+	let terminate: ((error: Error) => void) | undefined;
 	vi.spyOn(CodexAppServerClient, "start").mockImplementation(
-		async (options) =>
-			({
+		async (options) => {
+			terminate = options.onUnexpectedTermination;
+			return {
 				request: vi.fn(async (method: string, params?: unknown) => {
 					const record = (params ?? {}) as Record<string, unknown>;
 					switch (method) {
 						case "config/mcpServer/reload":
 							return {};
 						case "mcpServerStatus/list":
+							if (terminateOnMcpInventory && !startupTerminated) {
+								startupTerminated = true;
+								const error = new Error(
+									"Codex app-server exited with code 17 during startup",
+								);
+								options.onUnexpectedTermination?.(error);
+								throw error;
+							}
 							mcpInventoryReads += 1;
 							return {
 								data: [
@@ -118,8 +132,15 @@ const installAppServer = (
 					}
 				}),
 				close: vi.fn(),
-			}) as unknown as CodexAppServerClient,
+			} as unknown as CodexAppServerClient;
+		},
 	);
+	return {
+		terminate: (error: Error) => {
+			if (terminate === undefined) throw new Error("App server is not running");
+			terminate(error);
+		},
+	};
 };
 
 const withSession = async <A>(
@@ -128,14 +149,20 @@ const withSession = async <A>(
 		readonly forkFromResume?: boolean;
 		readonly missingResume?: boolean;
 		readonly initialMissingMcpInventories?: number;
+		readonly terminateOnMcpInventory?: boolean;
+		readonly onUnexpectedTermination?: (error: Error) => void;
 	},
-	use: (handle: CodexSessionHandle) => Promise<A>,
+	use: (
+		handle: CodexSessionHandle,
+		appServer: ReturnType<typeof installAppServer>,
+	) => Promise<A>,
 ): Promise<A> => {
 	const cwd = mkdtempSync(join(tmpdir(), "zuse-codex-lifecycle-"));
 	try {
-		installAppServer(
+		const appServer = installAppServer(
 			options.missingResume ?? false,
 			options.initialMissingMcpInventories ?? 0,
+			options.terminateOnMcpInventory ?? false,
 		);
 		const handle = await Effect.runPromise(
 			startCodexSession(
@@ -150,10 +177,11 @@ const withSession = async <A>(
 				"bun",
 				null,
 				options.resumeCursor ?? null,
+				options.onUnexpectedTermination,
 			).pipe(Effect.provide(AttachmentsTest)),
 		);
 		try {
-			return await use(handle);
+			return await use(handle, appServer);
 		} finally {
 			await Effect.runPromise(handle.close());
 		}
@@ -180,6 +208,85 @@ afterEach(() => {
 });
 
 describe("Codex session cursor persistence", () => {
+	it("ends an idle stream once without inventing a turn failure", async () => {
+		const onUnexpectedTermination = vi.fn();
+		await withSession(
+			{ onUnexpectedTermination },
+			async (handle, appServer) => {
+				const scoped = await Effect.runPromise(
+					makeTurnScopedSessionHandle(handle),
+				);
+				const collected = Effect.runFork(Stream.runCollect(scoped.events));
+				appServer.terminate(new Error("idle process exited"));
+				appServer.terminate(new Error("duplicate exit signal"));
+				const events = await Effect.runPromise(
+					Fiber.join(collected).pipe(Effect.timeout("2 seconds")),
+				);
+				expect(events.some((event) => event.scope === "turn")).toBe(false);
+				expect(onUnexpectedTermination).toHaveBeenCalledTimes(1);
+				expect(onUnexpectedTermination.mock.calls[0]?.[0].message).toBe(
+					"idle process exited",
+				);
+			},
+		);
+	});
+
+	it("does not start a compatibility fallback after the HTTP process dies", async () => {
+		await expect(
+			withSession({ terminateOnMcpInventory: true }, async () => undefined),
+		).rejects.toMatchObject({
+			reason: expect.stringContaining(
+				"Codex app-server exited with code 17 during startup",
+			),
+		});
+		expect(CodexAppServerClient.start).toHaveBeenCalledTimes(1);
+	});
+
+	it("publishes one terminal error and ends after app-server termination", async () => {
+		const onUnexpectedTermination = vi.fn();
+		await withSession(
+			{ onUnexpectedTermination },
+			async (handle, appServer) => {
+				const scoped = await Effect.runPromise(
+					makeTurnScopedSessionHandle(handle),
+				);
+				const collected = Effect.runFork(Stream.runCollect(scoped.events));
+				const turnId = "turn-crashed" as AgentTurnId;
+				await Effect.runPromise(scoped.send(turnId, "hello"));
+				await Effect.runPromise(Effect.sleep("30 millis"));
+
+				appServer.terminate(
+					new Error(
+						"Codex app-server exited with code 17\nCodex stderr (tail):\nfatal marker",
+					),
+				);
+				const events = Array.from(
+					await Effect.runPromise(
+						Fiber.join(collected).pipe(Effect.timeout("2 seconds")),
+					),
+				);
+
+				expect(events.slice(-2)).toEqual([
+					{
+						scope: "turn",
+						turnId,
+						event: {
+							_tag: "Error",
+							message:
+								"Codex app-server exited with code 17\nCodex stderr (tail):\nfatal marker",
+						},
+					},
+					{
+						scope: "turn",
+						turnId,
+						event: { _tag: "Completed", reason: "error" },
+					},
+				]);
+				expect(onUnexpectedTermination).toHaveBeenCalledTimes(1);
+			},
+		);
+	});
+
 	it("waits for the process-scoped MCP inventory to finish loading", async () => {
 		await withSession({ initialMissingMcpInventories: 1 }, async (handle) => {
 			const events = await takeEvents(handle.events, 1);

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -34,6 +34,7 @@
 		"./terminal-resource": "./src/terminal-resource.ts",
 		"./terminal-resource-driver": "./src/terminal-resource-driver.ts",
 		"./media": "./src/media.ts",
+		"./mermaid-source-policy": "./src/mermaid-source-policy.ts",
 		"./terminal-input-pump": "./src/terminal-input-pump.ts",
 		"./tool-image-result": "./src/tool-image-result.ts",
 		"./ws-protocol": "./src/ws-protocol.ts"

--- a/packages/client-runtime/src/mermaid-source-policy.ts
+++ b/packages/client-runtime/src/mermaid-source-policy.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025-present Mohamed Boudra.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Modified for Zuse on 2026-08-23; see THIRD_PARTY_NOTICES.md.
+ */
+
+/**
+ * Mermaid may load external images while it is still constructing a diagram,
+ * before its strict-mode SVG sanitization runs. Model-generated diagrams are
+ * therefore untrusted input: reject resource-bearing syntax before handing it
+ * to Mermaid and show the source block instead.
+ *
+ * This intentionally rejects every shape-data object (`@{ ... }`). Mermaid
+ * parses those objects as YAML, whose aliases and alternate key forms make a
+ * narrow `img`/`icon` key filter unsafe without using Mermaid's own parser.
+ * Formatting-only `<br>` and `<i>` labels remain available; all other HTML and
+ * numeric entities fail closed.
+ *
+ * Upstream context: https://github.com/mermaid-js/mermaid/issues/7645
+ */
+const UNSAFE_MERMAID_SOURCE =
+	/@\s*\{|url\s*\(|@import\b|themecss|&#|<(?!\/?(?:br|i)\s*\/?>)[a-z!?/]/iu;
+
+const ESCAPED_CODE_POINT =
+	/\\(?:u\{([0-9a-fA-F]{1,8})\}|U([0-9a-fA-F]{8})|u([0-9a-fA-F]{4})|x([0-9a-fA-F]{2}))/gu;
+
+const decodeCodePoint = (hex: string): string => {
+	const value = Number.parseInt(hex, 16);
+	if (!Number.isInteger(value) || value < 0 || value > 0x10ffff) {
+		throw new RangeError("Invalid Unicode code point");
+	}
+	return String.fromCodePoint(value);
+};
+
+/** Decode escape forms Mermaid/YAML can interpret so a denylisted token cannot
+ * be hidden behind quoted Unicode escapes. Invalid code points fail closed. */
+const normalizedMermaidSource = (source: string): string | null => {
+	try {
+		return source
+			.replace(
+				ESCAPED_CODE_POINT,
+				(_match, braced, long, short, byte: string | undefined) =>
+					decodeCodePoint(braced ?? long ?? short ?? byte ?? ""),
+			)
+			.replace(/["'`\\]/gu, "");
+	} catch {
+		return null;
+	}
+};
+
+export const containsUnsafeMermaidSource = (source: string): boolean => {
+	if (UNSAFE_MERMAID_SOURCE.test(source)) return true;
+	const normalized = normalizedMermaidSource(source);
+	return normalized === null || UNSAFE_MERMAID_SOURCE.test(normalized);
+};
+
+/** Fresh objects keep Mermaid's mutable configuration isolated per client. */
+export const mermaidSecurityConfig = () => ({
+	startOnLoad: false,
+	securityLevel: "strict" as const,
+	secure: [
+		"secure",
+		"securityLevel",
+		"startOnLoad",
+		"maxTextSize",
+		"suppressErrorRendering",
+		"maxEdges",
+		"htmlLabels",
+		"theme",
+		"themeVariables",
+		"themeCSS",
+	],
+	suppressErrorRendering: true,
+	htmlLabels: false,
+	flowchart: { htmlLabels: false },
+	class: { htmlLabels: false },
+});

--- a/packages/client-runtime/test/unit/mermaid-source-policy.test.ts
+++ b/packages/client-runtime/test/unit/mermaid-source-policy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	containsUnsafeMermaidSource,
+	mermaidSecurityConfig,
+} from "../../src/mermaid-source-policy.ts";
+
+describe("mermaidSecurityConfig", () => {
+	it("locks security settings and returns isolated configuration objects", () => {
+		const config = mermaidSecurityConfig();
+		expect(config.securityLevel).toBe("strict");
+		expect(config.htmlLabels).toBe(false);
+		expect(config.suppressErrorRendering).toBe(true);
+		expect(config.secure).toEqual(
+			expect.arrayContaining([
+				"secure",
+				"securityLevel",
+				"htmlLabels",
+				"theme",
+				"themeVariables",
+				"themeCSS",
+			]),
+		);
+		config.secure.length = 0;
+		config.flowchart.htmlLabels = true;
+		expect(mermaidSecurityConfig().secure.length).toBeGreaterThan(0);
+		expect(mermaidSecurityConfig().flowchart.htmlLabels).toBe(false);
+	});
+});
+
+describe("containsUnsafeMermaidSource", () => {
+	it("rejects constructs that can load external resources", () => {
+		const unsafe = [
+			'flowchart TD\n  A@{ img: "https://attacker.example/secret.png" }',
+			"flowchart TD\n  A@{ icon: 'pack:name' }",
+			'%%{init: {"themeCSS": "a { background: url(https://attacker.example) }"}}%%\ngraph TD',
+			"graph TD\n  A[url(https://attacker.example)]",
+			"graph TD\n  A[@import 'https://attacker.example/style.css']",
+			'graph TD\n  A["<img src=https://attacker.example/secret>"]',
+			'graph TD\n  A["<style>@import https://attacker.example</style>"]',
+			'graph TD\n  A["<i class=resource-bearing>styled</i>"]',
+			'graph TD\n  A["</b>"]',
+			'graph TD\n  A["&#60;img src=x&#62;"]',
+		];
+
+		for (const source of unsafe) {
+			expect(containsUnsafeMermaidSource(source), source).toBe(true);
+		}
+	});
+
+	it("rejects all shape-data forms instead of attempting partial YAML parsing", () => {
+		const unsafe = [
+			"flowchart TD\n  A@{ shape: rect }",
+			'flowchart TD\n  A@{ "img": "https://attacker.example/x" }',
+			'flowchart TD\n  A@{ "\\u0069mg": "https://attacker.example/x" }',
+			'flowchart TD\n  A@{ "\\u{69}mg": "https://attacker.example/x" }',
+			'flowchart TD\n  A@{ "\\x69mg": "https://attacker.example/x" }',
+		];
+
+		for (const source of unsafe) {
+			expect(containsUnsafeMermaidSource(source), source).toBe(true);
+		}
+	});
+
+	it("decodes disguised denylisted syntax and fails closed on invalid escapes", () => {
+		expect(
+			containsUnsafeMermaidSource(
+				'%%{init: {"theme\\u0043SS": "body { color: red }"}}%%\ngraph TD',
+			),
+		).toBe(true);
+		expect(
+			containsUnsafeMermaidSource('graph TD\n  A["<\\u0069mg src=x>"]'),
+		).toBe(true);
+		expect(containsUnsafeMermaidSource('graph TD\n  A["\\u{110000}"]')).toBe(
+			true,
+		);
+		expect(() =>
+			containsUnsafeMermaidSource('graph TD\n  A["\\UFFFFFFFF"]'),
+		).not.toThrow();
+		expect(containsUnsafeMermaidSource('graph TD\n  A["\\UFFFFFFFF"]')).toBe(
+			true,
+		);
+	});
+
+	it("allows ordinary diagrams and formatting-only labels", () => {
+		const safe = [
+			"flowchart TD\n  A[Start] --> B{Choice}",
+			'graph TD\n  A["line one<br>line two"]',
+			'graph TD\n  A["line one<br/>line two"]',
+			'graph TD\n  A["<i>formatted</i>"]',
+			"sequenceDiagram\n  Alice->>Bob: a < b and x > y",
+			'graph TD\n  A["https://example.com shown as text"]',
+		];
+
+		for (const source of safe) {
+			expect(containsUnsafeMermaidSource(source), source).toBe(false);
+		}
+	});
+});

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -1,5 +1,5 @@
-import { Rpc } from "effect/unstable/rpc";
 import { Schema } from "effect";
+import { Rpc } from "effect/unstable/rpc";
 
 /**
  * Every action the renderer can dispatch via a keybinding or menu click. The
@@ -14,43 +14,44 @@ import { Schema } from "effect";
  *   - `editor.*` commands fire inside the file editor (CodeMirror).
  */
 export const Command = Schema.Literals([
-  // menu / global
-  "new-chat",
-  "open-project",
-  "settings",
-  "close-tab",
-  "toggle-left-sidebar",
-  "toggle-right-sidebar",
-  "toggle-terminal",
-  "focus-composer",
-  // navigation — drive tabs / chats / panes from the keyboard
-  "next-tab",
-  "prev-tab",
-  "select-tab-1",
-  "select-tab-2",
-  "select-tab-3",
-  "select-tab-4",
-  "select-tab-5",
-  "select-tab-6",
-  "select-tab-7",
-  "select-tab-8",
-  "select-last-tab",
-  "new-tab",
-  "next-chat",
-  "prev-chat",
-  "next-panel",
-  "prev-panel",
-  "focus-next-pane",
-  "focus-prev-pane",
-  "open-chat-switcher",
-  // composer (chat input)
-  "composer.submit",
-  "composer.newline",
-  "composer.forceSubmit",
-  "composer.togglePlanMode",
-  // file editor
-  "editor.save",
-  "editor.annotate",
+	// menu / global
+	"new-chat",
+	"open-project",
+	"settings",
+	"close-tab",
+	"toggle-left-sidebar",
+	"toggle-right-sidebar",
+	"toggle-terminal",
+	"focus-composer",
+	// navigation — drive tabs / chats / panes from the keyboard
+	"next-tab",
+	"prev-tab",
+	"select-tab-1",
+	"select-tab-2",
+	"select-tab-3",
+	"select-tab-4",
+	"select-tab-5",
+	"select-tab-6",
+	"select-tab-7",
+	"select-tab-8",
+	"select-last-tab",
+	"new-tab",
+	"next-chat",
+	"prev-chat",
+	"next-panel",
+	"prev-panel",
+	"focus-next-pane",
+	"focus-prev-pane",
+	"open-chat-switcher",
+	"search-files",
+	// composer (chat input)
+	"composer.submit",
+	"composer.newline",
+	"composer.forceSubmit",
+	"composer.togglePlanMode",
+	// file editor
+	"editor.save",
+	"editor.annotate",
 ]);
 export type Command = typeof Command.Type;
 
@@ -70,9 +71,9 @@ export type Command = typeof Command.Type;
  * actual class instances. Matches the `RepositorySettingsPatch` convention.
  */
 export const KeybindingRule = Schema.Struct({
-  key: Schema.String,
-  command: Command,
-  when: Schema.optional(Schema.String),
+	key: Schema.String,
+	command: Command,
+	when: Schema.optional(Schema.String),
 });
 export type KeybindingRule = typeof KeybindingRule.Type;
 
@@ -82,22 +83,22 @@ export type KeybindingRule = typeof KeybindingRule.Type;
  * build can change them without rewriting the user's file.
  */
 export class KeybindingsFile extends Schema.Class<KeybindingsFile>(
-  "KeybindingsFile",
+	"KeybindingsFile",
 )({
-  schemaVersion: Schema.Literal(1),
-  rules: Schema.Array(KeybindingRule),
+	schemaVersion: Schema.Literal(1),
+	rules: Schema.Array(KeybindingRule),
 }) {}
 
 /** Safety cap. Truncates oldest if exceeded. */
 export const MAX_KEYBINDING_RULES = 256;
 
 export const KeybindingsGetRpc = Rpc.make("keybindings.get", {
-  success: KeybindingsFile,
+	success: KeybindingsFile,
 });
 
 export const KeybindingsReplaceRpc = Rpc.make("keybindings.replace", {
-  payload: Schema.Struct({ rules: Schema.Array(KeybindingRule) }),
-  success: KeybindingsFile,
+	payload: Schema.Struct({ rules: Schema.Array(KeybindingRule) }),
+	success: KeybindingsFile,
 });
 
 /**
@@ -106,6 +107,6 @@ export const KeybindingsReplaceRpc = Rpc.make("keybindings.replace", {
  * external hand-edit picked up by the file watcher).
  */
 export const KeybindingsStreamRpc = Rpc.make("keybindings.stream", {
-  success: KeybindingsFile,
-  stream: true,
+	success: KeybindingsFile,
+	stream: true,
 });

--- a/tests/system/test/desktop/electron-chat.desktop.test.ts
+++ b/tests/system/test/desktop/electron-chat.desktop.test.ts
@@ -88,6 +88,23 @@ describe("built Electron application", () => {
 			await expect.poll(() => quickOpen.count()).toBe(1);
 			await electron.page.keyboard.press("Escape");
 			await expect.poll(() => quickOpen.count()).toBe(0);
+			await electron.page.keyboard.press("ControlOrMeta+k");
+			await quickOpen.fill("Search files");
+			await electron.page.keyboard.press("Enter");
+			const fileSearch = electron.page.getByRole("combobox", {
+				name: "Search files",
+				exact: true,
+			});
+			await fileSearch.waitFor({ state: "visible" });
+			await expect.poll(() => quickOpen.count()).toBe(0);
+			await fileSearch.fill("README.md");
+			await electron.page
+				.getByRole("option", { name: "README.md", exact: true })
+				.waitFor({ state: "visible" });
+			await electron.page.keyboard.press("Escape");
+			await electron.page.keyboard.press("ControlOrMeta+p");
+			await fileSearch.waitFor({ state: "visible" });
+			await electron.page.keyboard.press("Escape");
 			const composer = electron.page
 				.locator(".cm-content[contenteditable='true']")
 				.last();

--- a/tests/system/test/desktop/electron-chat.desktop.test.ts
+++ b/tests/system/test/desktop/electron-chat.desktop.test.ts
@@ -60,9 +60,43 @@ describe("built Electron application", () => {
 				.getByText(conversation.chat.title, { exact: true })
 				.first()
 				.click();
+			await electron.page.keyboard.press("ControlOrMeta+k");
+			const quickOpen = electron.page.getByRole("combobox", {
+				name: "Search chats and commands",
+			});
+			await quickOpen.fill(">settings");
+			await electron.page.keyboard.press("Enter");
+			await expect.poll(() => quickOpen.count()).toBe(0);
+			await electron.page.keyboard.press("ControlOrMeta+k");
+			await quickOpen.fill(">");
+			await electron.page.keyboard.press("Tab");
+			await expect
+				.poll(() => quickOpen.evaluate((el) => el === document.activeElement))
+				.toBe(true);
+			await electron.page.keyboard.press("ArrowDown");
+			await expect
+				.poll(() =>
+					electron.page.getByRole("option", { selected: true }).textContent(),
+				)
+				.toContain("Open project");
+			await quickOpen.fill(">settings");
+			await electron.page.keyboard.press("Enter");
+			await expect.poll(() => quickOpen.count()).toBe(0);
+			await electron.page.keyboard.press("ControlOrMeta+k");
+			await quickOpen.fill("no-matching-chat-ship-check");
+			await electron.page.keyboard.press("Enter");
+			await expect.poll(() => quickOpen.count()).toBe(1);
+			await electron.page.keyboard.press("Escape");
+			await expect.poll(() => quickOpen.count()).toBe(0);
 			const composer = electron.page
 				.locator(".cm-content[contenteditable='true']")
 				.last();
+			await electron.page.keyboard.press("ControlOrMeta+k");
+			await quickOpen.fill(">focus composer");
+			await electron.page.keyboard.press("Enter");
+			await expect
+				.poll(() => composer.evaluate((el) => el === document.activeElement))
+				.toBe(true);
 			await composer.fill("Electron system message");
 			await electron.page.getByRole("button", { name: "Send" }).click();
 			try {


### PR DESCRIPTION
## Summary

- Redesign Cmd+K with a rounded inset results panel, a ring-free search header, five recent chats, a scrollable list of quick actions, settings destinations, workspace/navigation commands, shortcut labels, and a fixed keyboard-hint footer. Search together without a prefix; retain `>` for application commands only. Older chats remain searchable. Settings destinations share their metadata and visibility rules with the settings sidebar.
- Add Search files to quick actions and Cmd/Ctrl+P. Reuse the file tree's live resource, preserve project/environment/worktree identity when opening a match, and report loading, unavailable, cached, or partial results. The file-tree search button and global shortcut now use one shared file finder and command-dialog surface. Only one search modal can be open at a time.
- Harden Mermaid rendering on desktop and mobile with one shared source policy and security configuration. Reject resource-bearing syntax before rendering, keep strict mode and HTML labels locked, and display an error instead of rendering unsafe diagrams. Desktop also preserves the diagram source for inspection.
- Handle unexpected Codex app-server termination: reject pending requests, retain at most 4 KiB of stderr for diagnostics, settle an active turn once, end idle streams, release question waiters, and remove only the crashed provider generation so later work can start a fresh process.
- Package the existing license and attribution notices with the desktop app. Update the README and changelog.

## Scope and limits

- No new dependencies, database migrations, provider integrations, or release-version changes.
- Palette icons use the existing `@zuse/icons/solid-rounded` export; this repository currently maps it to the free outline icon set.
- File-search results use the shared file-type icons and colors, including Markdown, React/TSX, TypeScript, and named configuration files.
- Command mode exposes application/navigation commands, not editor/composer-only actions; context-dependent commands retain their existing behavior.
- Diagram validation deliberately rejects all `@{ ... }` shape-data syntax, including non-image shapes. This is defense in depth, not a complete rendering sandbox.
- Crash recovery makes a fresh process available for subsequent work; it does not promise automatic replay of a failed turn.

## Review and verification

- Rebased onto `main` at `c8e4080c`, preserving the model-catalog integration and all PR changes. Post-rebase checks passed: renderer 762 tests, agents 254 tests, contracts 148 tests; renderer/agents/contracts/desktop types; architecture boundaries; applicable Biome checks (existing driver diagnostics only); renderer build budgets.

- Updated the branch onto current `main` and preserved the authentication changes and tests during conflict resolution.
- Removed duplicate diagram-security configuration and fixed modal focus handoff during review.
- Renderer unit suite: 149 files, 762 tests passed, including recent-chat limits, mixed search, shared settings destinations, file matching, file-type icon rendering, execution-target preservation, connection feedback, and single-modal behavior.
- Contracts unit suite: 10 files, 140 tests passed. Renderer, desktop, and contracts type checks passed after the file-search command addition.
- Agent/client-runtime suites and provider-registry tests: 52 files, 411 tests passed.
- Full server unit/integration suite: 89 files, 628 tests passed after rebuilding the sandbox's native terminal dependency.
- Type checks passed for agents, server, renderer, mobile, and client-runtime.
- Applicable Biome checks passed with no errors. The existing driver file retains two pre-existing warnings and twenty informational diagnostics.
- Architecture boundaries and packaged legal-resource paths passed; whitespace/conflict checks passed.
- Browser component checks passed: older-chat selection, mixed search, command dispatch, arrow wrapping and scrolling, empty results, Tab containment, Escape/focus restoration, focus-composer handoff, valid diagram rendering, and blocked external-image syntax. Light/dark dialog accessibility audits: zero violations. Checked 720×480 and 375×667 layouts and long-title truncation without horizontal overflow.
- Browser checks also covered Search files handoff and selection, Cmd/Ctrl+P dispatch, switching between search modals, direct settings navigation, and the real no-project file-search state. File-finder and empty-state accessibility audits: zero violations.
- Desktop regression coverage was added for the keyboard workflow.

## Build size

Production renderer build passed all existing gzip budgets:

| Asset group | Size | Budget |
| --- | ---: | ---: |
| Initial JavaScript | 75.2 KiB | 200 KiB |
| Initial CSS | 44.3 KiB | 100 KiB |
| Default-route JavaScript | 494.2 KiB | 500 KiB |
| Largest lazy chunk | 224.9 KiB | 250 KiB |

These are size-budget checks, not a claim of measured end-to-end speedup.

## Outstanding verification

- Repository-wide `bun run check-types` fails in unchanged `apps/server/src/voice/handlers.ts:125`: `Uint8Array<ArrayBufferLike>` is not assignable to `BlobPart` when checked by the system-test workspace. The source, type configuration, and lockfile are unchanged by this PR.
- The built Electron regression and signed/native package checks have not run here. The sandbox lacks an installed Electron binary and built desktop application. Browser checks used the actual renderer components with an isolated test page, not a complete desktop session.

## Documentation

- README: documents command discovery through quick open.
- Changelog: records command search, diagram hardening, crash handling, and packaged notices under Unreleased.

