### PR TITLE
Release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0]
+
 ### Added
-- Cmd+K quick open has a rounded, height-limited, scrollable dialog with five recent chats, quick actions, settings destinations, workspace/navigation commands, and keyboard hints; search together, or start with `>` for commands only
-- Search project/worktree files with Cmd+P or the Search files quick action, using the same live file source and dialog as the file-tree search
-- New chats can now choose between the main checkout and a fresh isolated worktree directly from the composer
+- Find chats, application commands, settings, and workspace actions together with Cmd/Ctrl+K; use `>` to search commands only, or Cmd/Ctrl+P to search project and worktree files
+- Organize sidebar projects into named groups with colored folder icons, and drag projects or groups to reorder them
+- Choose the main checkout or a fresh isolated worktree directly from the composer when starting a chat
+- Select Fable 5.1 and GPT-6 Astra, now the defaults for Claude and Codex respectively
+- Access account cloud chats from mobile without an online desktop, read saved history while compute sleeps, and start chats in existing cloud projects; availability depends on compatible cloud services and workspace images
 
 ### Changed
-- The desktop interface now uses a darker green-neutral design system with a bottom-docked composer, compact settings and authentication dialogs, consistent segmented tabs, and cleaner project, computer, model, and reasoning controls
-- Imported chats, Cloud Workspace setup, approval questions, and permission prompts are denser and easier to scan
+- Model choices refresh from a cached online catalog and provider inventories, allowing catalog additions without a desktop update while retaining an offline fallback
+- The desktop interface has a bottom-docked composer, compact settings and authentication dialogs, and clearer project, computer, model, and reasoning controls
+- Service URLs appear as compact clickable links in the composer and user messages, with clearer skill references
 
 ### Fixed
-- Mermaid diagrams on desktop and mobile now reject external-resource syntax before rendering and lock security-sensitive configuration
-- Codex sessions now surface unexpected app-server exits, retire dead provider handles, and allow durable work to restart on a fresh process
-- Desktop packages now include Zuse's license and third-party attribution notices
-- Cloud sandbox images now preconfigure authenticated Git and GitHub CLI access, lazily minting and caching renewable repository credentials only when a GitHub command runs
-- Composer queues now stay held while the app is offline, resume on reconnect, and keep local desktop transports from being marked offline when only browser network connectivity drops
-- Cloud text messages can now be accepted while compute sleeps, wake the workspace through a durable encrypted mailbox, survive client/runtime restarts without duplicate provider sends, and report queued, cancelled, expired, or unknown outcomes explicitly
-- Cloud chats now automatically reconnect a failed client when the control plane reports that sandbox compute is ready, instead of showing a dead chat beside a working cloud terminal
-- The packaged `zusehq` CLI now discovers and authenticates to a foreground Serve process, reconnects after Serve restarts, and reports protocol mismatch, rejected credentials, and unavailable servers distinctly
-- Cloud chats now show Codex authentication recovery when OpenAI rejects saved credentials instead of mislabeling the provider failure as a workspace connection failure
-- Recovered Cloud Workspaces now show that only the live client needs reconnecting, and Retry restores that client instead of leaving a stale connection failure
-- Established Cloud Workspaces no longer replace missing runtime storage with an empty sandbox or project stale session metadata across runtime generations; cached transcripts remain visible with an explicit workspace-data error
-- One malformed legacy cloud resource can no longer cancel the reconciliation batch and leave unrelated workspaces stuck waiting; unsupported providers are retired explicitly while every other due resource continues independently
-- New Cloud Workspaces now carry the resolved global or repository permission default into the agent session instead of falling back to approval-required mode
+- Eligible cloud text messages can be accepted while compute sleeps and survive reconnects and restarts, with explicit delivery outcomes and protection against duplicate sends
+- Offline composer queues resume after reconnecting, and recovered Cloud Workspaces reconnect their chat client instead of leaving a stale connection error
+- Cloud chats distinguish rejected Codex credentials from connection failures, and new workspaces preserve configured permission defaults
+- Cloud workspaces report missing runtime data while preserving cached transcripts, and malformed legacy resources no longer block recovery of unrelated workspaces
+- Cloud sandbox images preconfigure authenticated Git and GitHub CLI access with renewable repository credentials
+- Active chats recover when their tabs are missing, archived project chats remain accessible, and startup progress hands off more reliably
+- Unexpected Codex process exits settle active turns and release crashed provider handles so subsequent work can start a fresh process
+- Mermaid diagrams on desktop and mobile reject external-resource syntax and enforce security-sensitive rendering settings
+- The packaged zusehq CLI discovers and authenticates to a foreground Serve process, reconnects after restarts, and distinguishes connection and authentication errors
+- Desktop packages include the application license and third-party attribution notices
 
 ## [0.20.13]
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
 	"name": "desktop",
 	"type": "module",
 	"productName": "Zuse (Beta)",
-	"version": "0.20.13",
+	"version": "0.21.0",
 	"description": "Zuse (Beta) desktop app",
 	"private": true,
 	"author": {

--- a/apps/server/src/voice/handlers.ts
+++ b/apps/server/src/voice/handlers.ts
@@ -122,7 +122,7 @@ const upload = async (
 		const form = new FormData();
 		form.append(
 			"file",
-			new Blob([bytes], { type: mimeType }),
+			new Blob([new Uint8Array(bytes)], { type: mimeType }),
 			mimeType.includes("mp4") ? "recording.m4a" : "recording.audio",
 		);
 		const response = await fetch(TRANSCRIPTION_ENDPOINT, {

--- a/apps/web/content/changelog.json
+++ b/apps/web/content/changelog.json
@@ -1,5 +1,43 @@
 [
   {
+    "version": "0.21.0",
+    "sections": [
+      {
+        "title": "Added",
+        "items": [
+          "Find chats, application commands, settings, and workspace actions together with Cmd/Ctrl+K; use `>` to search commands only, or Cmd/Ctrl+P to search project and worktree files",
+          "Organize sidebar projects into named groups with colored folder icons, and drag projects or groups to reorder them",
+          "Choose the main checkout or a fresh isolated worktree directly from the composer when starting a chat",
+          "Select Fable 5.1 and GPT-6 Astra, now the defaults for Claude and Codex respectively",
+          "Access account cloud chats from mobile without an online desktop, read saved history while compute sleeps, and start chats in existing cloud projects; availability depends on compatible cloud services and workspace images"
+        ]
+      },
+      {
+        "title": "Changed",
+        "items": [
+          "Model choices refresh from a cached online catalog and provider inventories, allowing catalog additions without a desktop update while retaining an offline fallback",
+          "The desktop interface has a bottom-docked composer, compact settings and authentication dialogs, and clearer project, computer, model, and reasoning controls",
+          "Service URLs appear as compact clickable links in the composer and user messages, with clearer skill references"
+        ]
+      },
+      {
+        "title": "Fixed",
+        "items": [
+          "Eligible cloud text messages can be accepted while compute sleeps and survive reconnects and restarts, with explicit delivery outcomes and protection against duplicate sends",
+          "Offline composer queues resume after reconnecting, and recovered Cloud Workspaces reconnect their chat client instead of leaving a stale connection error",
+          "Cloud chats distinguish rejected Codex credentials from connection failures, and new workspaces preserve configured permission defaults",
+          "Cloud workspaces report missing runtime data while preserving cached transcripts, and malformed legacy resources no longer block recovery of unrelated workspaces",
+          "Cloud sandbox images preconfigure authenticated Git and GitHub CLI access with renewable repository credentials",
+          "Active chats recover when their tabs are missing, archived project chats remain accessible, and startup progress hands off more reliably",
+          "Unexpected Codex process exits settle active turns and release crashed provider handles so subsequent work can start a fresh process",
+          "Mermaid diagrams on desktop and mobile reject external-resource syntax and enforce security-sensitive rendering settings",
+          "The packaged zusehq CLI discovers and authenticates to a foreground Serve process, reconnects after restarts, and distinguishes connection and authentication errors",
+          "Desktop packages include the application license and third-party attribution notices"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.20.13",
     "sections": [
       {

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "apps/desktop": {
       "name": "desktop",
-      "version": "0.20.13",
+      "version": "0.21.0",
       "dependencies": {
         "@cursor/sdk": "1.0.23",
         "electron-updater": "^6.3.9",


### PR DESCRIPTION
## Summary

Release Zuse 0.21.0. This minor release adds command/file search, sidebar groups, refreshed model discovery, and mobile account cloud workflows, alongside desktop polish and session reliability fixes.

### Added
- Find chats, application commands, settings, and workspace actions together with Cmd/Ctrl+K; use `>` to search commands only, or Cmd/Ctrl+P to search project and worktree files
- Organize sidebar projects into named groups with colored folder icons, and drag projects or groups to reorder them
- Choose the main checkout or a fresh isolated worktree directly from the composer when starting a chat
- Select Fable 5.1 and GPT-6 Astra, now the defaults for Claude and Codex respectively
- Access account cloud chats from mobile without an online desktop, read saved history while compute sleeps, and start chats in existing cloud projects; availability depends on compatible cloud services and workspace images

### Changed
- Model choices refresh from a cached online catalog and provider inventories, allowing catalog additions without a desktop update while retaining an offline fallback
- The desktop interface has a bottom-docked composer, compact settings and authentication dialogs, and clearer project, computer, model, and reasoning controls
- Service URLs appear as compact clickable links in the composer and user messages, with clearer skill references

### Fixed
- Eligible cloud text messages can be accepted while compute sleeps and survive reconnects and restarts, with explicit delivery outcomes and protection against duplicate sends
- Offline composer queues resume after reconnecting, and recovered Cloud Workspaces reconnect their chat client instead of leaving a stale connection error
- Cloud chats distinguish rejected Codex credentials from connection failures, and new workspaces preserve configured permission defaults
- Cloud workspaces report missing runtime data while preserving cached transcripts, and malformed legacy resources no longer block recovery of unrelated workspaces
- Cloud sandbox images preconfigure authenticated Git and GitHub CLI access with renewable repository credentials
- Active chats recover when their tabs are missing, archived project chats remain accessible, and startup progress hands off more reliably
- Unexpected Codex process exits settle active turns and release crashed provider handles so subsequent work can start a fresh process
- Mermaid diagrams on desktop and mobile reject external-resource syntax and enforce security-sensitive rendering settings
- The packaged zusehq CLI discovers and authenticates to a foreground Serve process, reconnects after restarts, and distinguishes connection and authentication errors
- Desktop packages include the application license and third-party attribution notices

## Release preparation

Updates the desktop version, lockfile, changelog, and generated website changelog. Includes a one-line voice-upload compatibility fix: copy the input bytes into an ArrayBuffer-backed view before constructing a Blob, resolving the existing system-workspace TS2322 error without changing the audio payload.

Account-level provider authentication remains disabled in production configuration; mobile cloud functionality depends on compatible services and images. This PR does not deploy those services or publish mobile binaries.

## Validation

- `bun run check-types`: passed across all workspaces after fixing voice-upload buffer compatibility.
- Website content generation and release version/note consistency checks passed.
- Website behavior suite: 44 tests passed.
- Voice policy suite: 2 tests passed; audio Blob probe preserved sliced bytes, MIME type, and snapshot isolation with ordinary and shared buffers.
- Architecture behavior suite: 8 tests passed.
- Biome source/manifest checks passed. Generated changelog lint passed with formatting disabled because its existing generator emits two-space JSON instead of Biome tabs.
- `git diff --check` passed.
- Frozen dependency install passed after installing missing native build tools. Licensed icons and signed desktop artifacts are verified by the tag-triggered release workflow.

After merge, tag the exact merged commit as v0.21.0, verify macOS/Linux artifacts, and publish the curated notes on the GitHub Release.

