### PR TITLE
Fix cloud access defaults, applied-mode UI, and approval recovery

### DIFF
--- a/apps/mobile/src/components/messages/live-permission-accessory.tsx
+++ b/apps/mobile/src/components/messages/live-permission-accessory.tsx
@@ -83,6 +83,41 @@ export function LivePermissionAccessory({
 		);
 	};
 
+	if (request.recoveryState === "expired") {
+		return (
+			<View
+				style={{ paddingBottom: Math.max(bottomInset, 8) }}
+				className="px-3 pt-2"
+			>
+				<GlassSurface style={{ padding: 16, gap: 12 }}>
+					<Text
+						accessibilityRole="text"
+						className="font-sans-bold text-foreground"
+					>
+						Approval expired after agent restart
+					</Text>
+					<Text
+						accessibilityLiveRegion="polite"
+						className="font-sans text-muted-foreground"
+					>
+						The agent can no longer consume this response. Dismiss it and send a
+						message to continue.
+					</Text>
+					<Text selectable className="font-mono text-muted-foreground">
+						{detail}
+					</Text>
+					{error === null ? null : <ErrorText message={error} />}
+					<PrimaryButton
+						label="Dismiss"
+						busy={busy}
+						loading={pendingAction === "deny"}
+						onPress={() => decide("deny", { _tag: "Deny" })}
+					/>
+				</GlassSurface>
+			</View>
+		);
+	}
+
 	return (
 		<View
 			pointerEvents="box-none"

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -281,6 +281,14 @@ export function ChatComposer({
 		isDraft ? "cache-only" : "connect",
 		qualifiedEnvironmentId,
 	);
+	// Catalog placeholders describe launch intent. Only the session timeline
+	// knows which access mode the runtime actually applied (also across devices).
+	const appliedRuntimeMode = isDraft
+		? session.runtimeMode
+		: (timeline.projection?.runtimeMode ?? session.runtimeMode);
+	const runtimeModePending = timeline.view.pendingCommands.some(
+		(command) => command.kind === "session.setRuntimeMode",
+	);
 	const goalRef = useMemo(
 		() => ({ environmentId: qualifiedEnvironmentId, sessionId }),
 		[qualifiedEnvironmentId, sessionId],
@@ -392,12 +400,21 @@ export function ChatComposer({
 		for (const req of Object.values(requestsById)) {
 			if (req.sessionId !== sessionId) continue;
 			// ExitPlanMode is approved on the plan card itself.
-			if (req.kind._tag === "Other" && req.kind.tool === "ExitPlanMode") {
+			if (
+				req.recoveryState !== "expired" &&
+				req.kind._tag === "Other" &&
+				req.kind.tool === "ExitPlanMode"
+			) {
 				continue;
 			}
 			out.push(req);
 		}
-		out.sort((a, b) => a.requestedAt.getTime() - b.requestedAt.getTime());
+		out.sort(
+			(a, b) =>
+				Number(a.recoveryState === "expired") -
+					Number(b.recoveryState === "expired") ||
+				a.requestedAt.getTime() - b.requestedAt.getTime(),
+		);
 		return out;
 	}, [requestsById, sessionId]);
 	const pendingPlanApprovalRequest = useMemo(
@@ -1282,6 +1299,7 @@ export function ChatComposer({
 					<div className={constrain ? "mx-auto w-full max-w-4xl" : "w-full"}>
 						{headPermission !== undefined ? (
 							<PermissionCard
+								key={`${qualifiedEnvironmentId}:${headPermission.id}:${headPermission.recoveryState ?? "live"}`}
 								head={headPermission}
 								queueSize={pendingPermissions.length}
 								environmentId={qualifiedEnvironmentId}
@@ -1502,7 +1520,9 @@ export function ChatComposer({
 										sessionId={sessionId}
 										environmentId={qualifiedEnvironmentId}
 										providerId={session.providerId}
-										current={session.runtimeMode}
+										current={appliedRuntimeMode}
+										pending={runtimeModePending}
+										confirmed={isDraft || timeline.projection !== null}
 									/>
 									{goalCapable ? (
 										<GoalModeToggle
@@ -1655,21 +1675,25 @@ function RuntimeAccessPicker({
 	environmentId,
 	providerId,
 	current,
+	pending,
+	confirmed,
 }: {
 	sessionId: SessionId;
 	environmentId: EnvironmentId;
 	providerId: ProviderId;
 	current: RuntimeMode;
+	pending: boolean;
+	confirmed: boolean;
 }) {
 	const setRuntimeMode = useSessionsStore((state) => state.setRuntimeMode);
 	const meta = MODE_META[current];
 	const fixedSandbox = providerId === "cursor";
-	const highlighted = current === "full-access";
+	const highlighted = confirmed && current === "full-access";
 
 	return (
 		<Menu>
 			<MenuTrigger
-				disabled={fixedSandbox}
+				disabled={fixedSandbox || pending}
 				aria-label={
 					fixedSandbox ? "Cursor uses fixed sandbox access" : "Agent access"
 				}
@@ -1681,7 +1705,18 @@ function RuntimeAccessPicker({
 				)}
 			>
 				<HugeiconsIcon icon={meta.Icon} className="size-3.5" />
-				<span>{fixedSandbox ? "Sandboxed" : meta.label}</span>
+				<span>
+					{fixedSandbox
+						? "Sandboxed"
+						: confirmed
+							? meta.label
+							: "Checking access…"}
+				</span>
+				{pending ? (
+					<span role="status" aria-live="polite">
+						Updating…
+					</span>
+				) : null}
 				{fixedSandbox ? null : <ChevronDown className="size-3 opacity-60" />}
 			</MenuTrigger>
 			<MenuPopup side="top" align="start" className="w-64 p-1">
@@ -1700,7 +1735,7 @@ function RuntimeAccessPicker({
 							<MenuRadioItem
 								key={mode}
 								value={mode}
-								className="h-8 px-2 text-xs"
+								className="h-7 px-2 text-xs"
 							>
 								<span className="flex min-w-0 items-center gap-2 font-medium text-foreground">
 									<HugeiconsIcon icon={option.Icon} className="size-3.5" />

--- a/apps/renderer/src/components/chat-composer.tsx
+++ b/apps/renderer/src/components/chat-composer.tsx
@@ -1552,6 +1552,7 @@ export function ChatComposer({
 									<ComposerModelPicker
 										environmentId={qualifiedEnvironmentId}
 										session={session}
+										runtimeMode={appliedRuntimeMode}
 										fastModeAvailable={
 											findModelDescriptor(
 												composerCatalog,
@@ -2152,12 +2153,14 @@ function GoalEditorDialog({
 function ComposerModelPicker({
 	environmentId,
 	session,
+	runtimeMode,
 	fastModeAvailable,
 	onLevelChange,
 	onOpenChange,
 }: {
 	environmentId: EnvironmentId;
 	session: Session;
+	runtimeMode: RuntimeMode;
 	fastModeAvailable: boolean;
 	onLevelChange?: (level: string | null) => void;
 	onOpenChange?: (open: boolean) => void;
@@ -2234,7 +2237,7 @@ function ComposerModelPicker({
 		mode: "session" as const,
 		sessionId,
 		chatId: session.chatId,
-		runtimeMode: session.runtimeMode,
+		runtimeMode,
 		providerId,
 		currentModel: model,
 		onOpenChange,

--- a/apps/renderer/src/components/chat-landing.tsx
+++ b/apps/renderer/src/components/chat-landing.tsx
@@ -35,6 +35,7 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import { Button } from "~/components/ui/button.tsx";
 import {
 	Menu,
 	MenuItem,
@@ -258,6 +259,7 @@ export function ChatLanding() {
 	const draftSession = useSessionsStore((s) => s.draftSession);
 
 	const [submitError, setSubmitError] = useState<string | null>(null);
+	const [draftAttempt, setDraftAttempt] = useState(0);
 	// Local "submit in flight" flag. Covers the whole creation window —
 	// including the worktree-create step — so the bridge shows the moment the
 	// user hits send rather than after the worktree exists.
@@ -598,13 +600,19 @@ export function ChatLanding() {
 					runtimeMode,
 				});
 			},
+			(cause) => {
+				if (cancelled) return;
+				setSubmitError(
+					`Couldn't load chat access settings. ${formatError(cause)}`,
+				);
+			},
 		);
 		return () => {
 			cancelled = true;
 			clearDraft();
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [activeEnvironmentId, selectedFolderId, remoteAnchor]);
+	}, [activeEnvironmentId, selectedFolderId, remoteAnchor, draftAttempt]);
 
 	const headline =
 		anchoredGroup !== null
@@ -1348,6 +1356,19 @@ export function ChatLanding() {
 						<div className="mx-auto flex w-full max-w-2xl items-start gap-2 rounded-lg border border-rose-400/30 bg-rose-500/[0.08] px-3 py-2 text-[12px] text-rose-200">
 							<span className="mt-px shrink-0">⚠</span>
 							<span className="flex-1 leading-snug">{submitError}</span>
+							{draftSession === null ? (
+								<Button
+									className="h-7"
+									size="xs"
+									variant="ghost"
+									onClick={() => {
+										setSubmitError(null);
+										setDraftAttempt((attempt) => attempt + 1);
+									}}
+								>
+									Retry
+								</Button>
+							) : null}
 							<button
 								type="button"
 								onClick={() => setSubmitError(null)}

--- a/apps/renderer/src/components/permission-card.tsx
+++ b/apps/renderer/src/components/permission-card.tsx
@@ -4,13 +4,14 @@ import type {
 	PermissionKind,
 	PermissionRequest,
 } from "@zuse/contracts";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { cn } from "~/lib/utils";
 import {
 	decideEnvironmentPermission,
 	denyEnvironmentPermissionAndInterrupt,
 } from "../lib/environment-permissions-client-bus.ts";
+import { formatError } from "../lib/format-error.ts";
 import { Button } from "./ui/button.tsx";
 
 const kindHeadline = (kind: PermissionKind): string => {
@@ -74,14 +75,31 @@ export function PermissionCard({
 	readonly queueSize: number;
 	readonly environmentId: EnvironmentId;
 }) {
+	const expired = head.recoveryState === "expired";
+	const [pending, setPending] = useState(false);
+	const [error, setError] = useState<string | null>(null);
 	const decide = useCallback(
-		(requestId: string, decision: PermissionDecision): Promise<void> =>
-			decideEnvironmentPermission(requestId, decision, environmentId),
-		[environmentId],
+		async (requestId: string, decision: PermissionDecision): Promise<void> => {
+			if (pending || (expired && decision._tag !== "Deny")) return;
+			setPending(true);
+			setError(null);
+			try {
+				if (decision._tag === "Deny" && !expired) {
+					await denyEnvironmentPermissionAndInterrupt(head, environmentId);
+				} else {
+					await decideEnvironmentPermission(requestId, decision, environmentId);
+				}
+			} catch (cause) {
+				setError(formatError(cause));
+			} finally {
+				setPending(false);
+			}
+		},
+		[environmentId, expired, head, pending],
 	);
 	const deny = useCallback(
-		() => denyEnvironmentPermissionAndInterrupt(head, environmentId),
-		[environmentId, head],
+		() => decide(head.id, { _tag: "Deny" }),
+		[decide, head.id],
 	);
 	const persistentDisabled = head.forcePrompt;
 
@@ -92,7 +110,7 @@ export function PermissionCard({
 				void deny();
 				return;
 			}
-			if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+			if (!expired && (e.metaKey || e.ctrlKey) && e.key === "Enter") {
 				e.preventDefault();
 				void decide(head.id, ALLOW_ONCE);
 				return;
@@ -100,13 +118,15 @@ export function PermissionCard({
 		};
 		document.addEventListener("keydown", onKey);
 		return () => document.removeEventListener("keydown", onKey);
-	}, [head.id, decide, deny]);
+	}, [head.id, decide, deny, expired]);
 
 	return (
 		<div className="rounded-xl bg-card/95 p-3 shadow-overlay-sm ring-1 ring-border/70">
 			<div className="flex items-center gap-2">
 				<div className="truncate text-[13px] font-medium leading-5 text-foreground">
-					{kindHeadline(head.kind)}
+					{expired
+						? "Approval expired after agent restart"
+						: kindHeadline(head.kind)}
 				</div>
 				{queueSize > 1 ? (
 					<span className="rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground shrink-0">
@@ -114,6 +134,21 @@ export function PermissionCard({
 					</span>
 				) : null}
 			</div>
+			{expired ? (
+				<p
+					className="mt-2 text-xs text-muted-foreground"
+					role="status"
+					aria-live="polite"
+				>
+					The agent restarted while waiting for this approval. It cannot consume
+					the old response. Dismiss this request and send a message to continue.
+				</p>
+			) : null}
+			{error ? (
+				<p role="alert" className="mt-2 text-xs text-destructive">
+					{error}
+				</p>
+			) : null}
 
 			<div className="mt-2 max-h-24 overflow-y-auto break-all rounded-md bg-muted/45 px-2.5 py-1.5 font-mono text-[11px] leading-4 text-foreground/90">
 				{kindDetail(head.kind)}
@@ -129,37 +164,50 @@ export function PermissionCard({
 				<Button
 					size="xs"
 					variant="ghost"
+					disabled={pending}
+					className="h-7"
 					onClick={() => void deny()}
 					title="Esc"
 				>
-					Deny
+					{expired ? "Dismiss" : "Deny"}
 				</Button>
-				<Button
-					size="xs"
-					variant="ghost"
-					disabled={persistentDisabled}
-					onClick={() => void decide(head.id, ALLOW_FOR_SESSION)}
-					className={cn(persistentDisabled && "pointer-events-none opacity-40")}
-				>
-					Allow for session
-				</Button>
-				<Button
-					size="xs"
-					variant="ghost"
-					disabled={persistentDisabled}
-					onClick={() => void decide(head.id, ALWAYS_ALLOW_FOLDER)}
-					className={cn(persistentDisabled && "pointer-events-none opacity-40")}
-				>
-					Always allow
-				</Button>
-				<Button
-					size="xs"
-					onClick={() => void decide(head.id, ALLOW_ONCE)}
-					className="ml-1"
-					title="⌘+Enter"
-				>
-					Allow once
-				</Button>
+				{expired ? null : (
+					<>
+						<Button
+							size="xs"
+							variant="ghost"
+							disabled={persistentDisabled || pending}
+							onClick={() => void decide(head.id, ALLOW_FOR_SESSION)}
+							className={cn(
+								"h-7",
+								persistentDisabled && "pointer-events-none opacity-40",
+							)}
+						>
+							Allow for session
+						</Button>
+						<Button
+							size="xs"
+							variant="ghost"
+							disabled={persistentDisabled || pending}
+							onClick={() => void decide(head.id, ALWAYS_ALLOW_FOLDER)}
+							className={cn(
+								"h-7",
+								persistentDisabled && "pointer-events-none opacity-40",
+							)}
+						>
+							Always allow
+						</Button>
+						<Button
+							size="xs"
+							disabled={pending}
+							onClick={() => void decide(head.id, ALLOW_ONCE)}
+							className="ml-1 h-7"
+							title="⌘+Enter"
+						>
+							Allow once
+						</Button>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/renderer/src/lib/auto-worktree.ts
+++ b/apps/renderer/src/lib/auto-worktree.ts
@@ -1,15 +1,16 @@
-import type {
-	ChatWorkspacePolicy,
+import {
+	type ChatWorkspacePolicy,
 	EnvironmentId,
-	FolderId,
-	RepositorySettings,
-	RuntimeMode,
+	type FolderId,
+	type RepositorySettings,
+	type RuntimeMode,
 } from "@zuse/contracts";
 
 import {
 	repositorySettingsKey,
 	useRepositorySettingsStore,
 } from "../store/repository-settings.ts";
+import { getActiveEnvironment } from "./rpc-client.ts";
 import {
 	resolveEnvironmentSettings,
 	useSettingsStore,
@@ -38,7 +39,9 @@ export async function resolveChatRuntimeMode(
 	projectId: FolderId,
 ): Promise<RuntimeMode> {
 	const [settings, repositorySettings] = await Promise.all([
-		resolveEnvironmentSettings(environmentId),
+		// Global preferences belong to the settings surface the user configured,
+		// not the destination sandbox's image. Capture that owner before awaiting.
+		resolveEnvironmentSettings(EnvironmentId.make(getActiveEnvironment())),
 		repositorySettingsFor(environmentId, projectId),
 	]);
 	return effectiveChatRuntimeMode(

--- a/apps/renderer/src/lib/auto-worktree.ts
+++ b/apps/renderer/src/lib/auto-worktree.ts
@@ -10,7 +10,10 @@ import {
 	repositorySettingsKey,
 	useRepositorySettingsStore,
 } from "../store/repository-settings.ts";
-import { useSettingsStore } from "./settings-client-bus.ts";
+import {
+	resolveEnvironmentSettings,
+	useSettingsStore,
+} from "./settings-client-bus.ts";
 
 const repositorySettingsFor = async (
 	environmentId: EnvironmentId,
@@ -34,9 +37,13 @@ export async function resolveChatRuntimeMode(
 	environmentId: EnvironmentId,
 	projectId: FolderId,
 ): Promise<RuntimeMode> {
+	const [settings, repositorySettings] = await Promise.all([
+		resolveEnvironmentSettings(environmentId),
+		repositorySettingsFor(environmentId, projectId),
+	]);
 	return effectiveChatRuntimeMode(
-		useSettingsStore.getState().defaultRuntimeMode,
-		await repositorySettingsFor(environmentId, projectId),
+		settings.defaultRuntimeMode,
+		repositorySettings,
 	);
 }
 

--- a/apps/renderer/src/lib/format-error.ts
+++ b/apps/renderer/src/lib/format-error.ts
@@ -20,6 +20,10 @@ const diagnosticErrorType = (value: unknown): string => {
 // fall through to a raw JSON dump like `{ "folderId": "…" }`. Map them to
 // human copy here so any surface that formats them stays readable.
 const TAG_MESSAGES: Record<string, string> = {
+	PermissionRequestExpiredError:
+		"The agent restarted and this approval expired. Dismiss it and send a message to continue.",
+	PermissionRequestNotFoundError:
+		"This approval is no longer pending. It may have been resolved on another device.",
 	GitNotARepoError: "This folder isn't a Git repository.",
 	DirectoryUnavailableError: "This directory is unavailable.",
 	GitFolderNotFoundError: "Project folder not found.",

--- a/apps/renderer/src/lib/session-timeline-client-bus.ts
+++ b/apps/renderer/src/lib/session-timeline-client-bus.ts
@@ -516,6 +516,9 @@ const executeSessionCommand: ClientCommandExecutor<MemoizeClient> = {
 					client["keybindings.replace"](payload as never),
 				);
 				break;
+			case "settings.get":
+				result = await Effect.runPromise(client["settings.get"]());
+				break;
 			case "settings.update":
 				result = await Effect.runPromise(
 					client["settings.update"](payload as never),

--- a/apps/renderer/src/lib/settings-client-bus.ts
+++ b/apps/renderer/src/lib/settings-client-bus.ts
@@ -431,6 +431,29 @@ const activeResource = () => {
 	};
 };
 
+/** Creation must not interpret an unhydrated settings cell as user intent. */
+export const resolveEnvironmentSettings = async (
+	environmentId: EnvironmentId,
+): Promise<SettingsSlice> => {
+	const bus = getRendererClientBus();
+	const key = keyFor(environmentId);
+	const cached = bus.snapshot(key).data;
+	if (cached !== null) return cached;
+	const { result } = await bus.dispatch<SettingsFile>({
+		kind: "settings.get",
+		commandId: CommandId.make(`settings-get:${crypto.randomUUID()}`),
+		environmentId,
+		resource: key,
+		payload: {},
+		retry: "safe",
+		createdAt: Date.now(),
+	});
+	return (
+		bus.snapshot(key).data ??
+		withPendingPatches(environmentId, fromFile(result))
+	);
+};
+
 const update = (patchFor: (current: SettingsSlice) => SettingsPatch): void => {
 	const { environmentId, key, bus } = activeResource();
 	const current = bus.snapshot(key)?.data ?? FALLBACK;

--- a/apps/renderer/src/store/sessions.ts
+++ b/apps/renderer/src/store/sessions.ts
@@ -694,13 +694,9 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 			set({ draftSession: Session.make({ ...draft, runtimeMode }) });
 			return;
 		}
-		// Optimistic — patch the local row before the RPC settles so the toggle
-		// feels instant. Server-side update is also fast (single SQL UPDATE +
-		// in-memory cache poke), so the round-trip is invisible in practice.
+		// Access is an applied runtime setting, not optimistic intent. The
+		// qualified timeline publishes RuntimeModeSet after the command commits.
 		set({ error: null });
-		patchActiveSession(sessionId, (session) =>
-			Session.make({ ...session, runtimeMode }),
-		);
 		try {
 			const commandId = nextCommandId("session-runtime-mode");
 			await dispatchTimelineCommand(
@@ -717,12 +713,6 @@ export const useSessionsStore = create<SessionsState>((set, get) => ({
 			);
 		} catch (err) {
 			set({ error: formatError(err) });
-			// Best-effort revert via re-hydrate of the affected project.
-			const projectId = findSessionProject(
-				activeSessionsByProject(),
-				sessionId,
-			);
-			if (projectId !== null) await get().hydrate(projectId);
 		}
 	},
 	setPermissionMode: async (sessionId, mode, environmentId) => {

--- a/apps/renderer/test/unit/chat-runtime-mode.test.ts
+++ b/apps/renderer/test/unit/chat-runtime-mode.test.ts
@@ -1,9 +1,56 @@
-import type { RepositorySettings } from "@zuse/contracts";
-import { describe, expect, it } from "vitest";
+import {
+	EnvironmentId,
+	FolderId,
+	type RepositorySettings,
+	SettingsFile,
+} from "@zuse/contracts";
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { effectiveChatRuntimeMode } from "../../src/lib/auto-worktree.ts";
+import {
+	effectiveChatRuntimeMode,
+	resolveChatRuntimeMode,
+} from "../../src/lib/auto-worktree.ts";
+import {
+	resetSessionTimelineClientBusForTest,
+	setSessionTimelineRpcClientForTest,
+} from "../../src/lib/session-timeline-client-bus.ts";
+import { useSettingsStore } from "../../src/lib/settings-client-bus.ts";
+
+vi.mock("../../src/store/repository-settings.ts", () => ({
+	repositorySettingsKey: (environmentId: string, projectId: string) =>
+		`${environmentId}:${projectId}`,
+	useRepositorySettingsStore: {
+		getState: () => ({ byProject: {}, refresh: async () => null }),
+	},
+}));
+
+afterEach(() => resetSessionTimelineClientBusForTest());
 
 describe("effectiveChatRuntimeMode", () => {
+	it("loads the selected environment's Full Access default before creating a draft", async () => {
+		const requested: EnvironmentId[] = [];
+		setSessionTimelineRpcClientForTest(async (environmentId) => {
+			requested.push(environmentId);
+			return {
+				"settings.get": () =>
+					Effect.succeed(
+						SettingsFile.make({
+							...useSettingsStore.getState(),
+							schemaVersion: 1,
+							mcpDisabledServers: [],
+							subagents: { enableForNewSessions: false, presets: {} },
+							defaultRuntimeMode: "full-access",
+						}),
+					),
+			} as never;
+		});
+		const environmentId = EnvironmentId.make("cloud-draft-origin");
+		expect(
+			await resolveChatRuntimeMode(environmentId, FolderId.make("project-1")),
+		).toBe("full-access");
+		expect(requested).toEqual([environmentId]);
+	});
 	it("uses a repository permission override for new chats", () => {
 		expect(
 			effectiveChatRuntimeMode("approval-required", {

--- a/apps/renderer/test/unit/chat-runtime-mode.test.ts
+++ b/apps/renderer/test/unit/chat-runtime-mode.test.ts
@@ -26,10 +26,14 @@ vi.mock("../../src/store/repository-settings.ts", () => ({
 	},
 }));
 
-afterEach(() => resetSessionTimelineClientBusForTest());
+afterEach(() => {
+	resetSessionTimelineClientBusForTest();
+	vi.unstubAllGlobals();
+});
 
 describe("effectiveChatRuntimeMode", () => {
 	it("loads the user's Full Access default before creating a cloud draft", async () => {
+		vi.stubGlobal("location", new URL("http://localhost"));
 		const requested: EnvironmentId[] = [];
 		setSessionTimelineRpcClientForTest(async (environmentId) => {
 			requested.push(environmentId);

--- a/apps/renderer/test/unit/chat-runtime-mode.test.ts
+++ b/apps/renderer/test/unit/chat-runtime-mode.test.ts
@@ -11,6 +11,7 @@ import {
 	effectiveChatRuntimeMode,
 	resolveChatRuntimeMode,
 } from "../../src/lib/auto-worktree.ts";
+import { getActiveEnvironment } from "../../src/lib/rpc-client.ts";
 import {
 	resetSessionTimelineClientBusForTest,
 	setSessionTimelineRpcClientForTest,
@@ -28,7 +29,7 @@ vi.mock("../../src/store/repository-settings.ts", () => ({
 afterEach(() => resetSessionTimelineClientBusForTest());
 
 describe("effectiveChatRuntimeMode", () => {
-	it("loads the selected environment's Full Access default before creating a draft", async () => {
+	it("loads the user's Full Access default before creating a cloud draft", async () => {
 		const requested: EnvironmentId[] = [];
 		setSessionTimelineRpcClientForTest(async (environmentId) => {
 			requested.push(environmentId);
@@ -49,7 +50,7 @@ describe("effectiveChatRuntimeMode", () => {
 		expect(
 			await resolveChatRuntimeMode(environmentId, FolderId.make("project-1")),
 		).toBe("full-access");
-		expect(requested).toEqual([environmentId]);
+		expect(requested).toEqual([getActiveEnvironment()]);
 	});
 	it("uses a repository permission override for new chats", () => {
 		expect(

--- a/apps/renderer/test/unit/close-chat-tab.test.ts
+++ b/apps/renderer/test/unit/close-chat-tab.test.ts
@@ -12,6 +12,9 @@ const canonical = vi.hoisted(() => ({
 }));
 
 vi.mock("../../src/lib/settings-client-bus.ts", () => ({
+	resolveEnvironmentSettings: async () => ({
+		defaultRuntimeMode: "full-access",
+	}),
 	useSettingsStore: {
 		getState: () => ({
 			defaultProviderId: "codex",

--- a/apps/renderer/test/unit/composer-access.test.tsx
+++ b/apps/renderer/test/unit/composer-access.test.tsx
@@ -1,0 +1,45 @@
+import { EnvironmentId, FolderId, Session, SessionId } from "@zuse/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ChatComposer } from "../../src/components/chat-composer.tsx";
+import { useSessionsStore } from "../../src/store/sessions.ts";
+
+// Provider/model inventory is independent of applied access and requires a live client.
+vi.mock("../../src/components/model-picker.tsx", () => ({
+	ModelPicker: () => null,
+}));
+
+vi.mock("../../src/lib/session-timeline-hooks.ts", async (original) => ({
+	...(await original<
+		typeof import("../../src/lib/session-timeline-hooks.ts")
+	>()),
+	useRendererSessionTimeline: () => ({
+		projection: { runtimeMode: "approval-required", queue: { items: [] } },
+		view: { data: null, pendingCommands: [], failedCommands: [], sync: "live" },
+		messages: [],
+		runtime: "idle",
+	}),
+}));
+
+describe("composer applied access", () => {
+	it("renders the runtime's applied access instead of a stale Full Access catalog row", () => {
+		const draft = useSessionsStore.getState().beginDraft({
+			projectId: FolderId.make("project-1"),
+			providerId: "codex",
+			model: "gpt-5.6-sol",
+			runtimeMode: "full-access",
+		});
+		const session = Session.make({
+			...draft,
+			id: SessionId.make("cloud-session"),
+		});
+		const html = renderToStaticMarkup(
+			<ChatComposer
+				session={session}
+				environmentId={EnvironmentId.make("cloud-1")}
+			/>,
+		);
+		expect(html).toContain("Supervised");
+		expect(html).not.toContain("Full access");
+	});
+});

--- a/apps/renderer/test/unit/composer-access.test.tsx
+++ b/apps/renderer/test/unit/composer-access.test.tsx
@@ -6,7 +6,9 @@ import { useSessionsStore } from "../../src/store/sessions.ts";
 
 // Provider/model inventory is independent of applied access and requires a live client.
 vi.mock("../../src/components/model-picker.tsx", () => ({
-	ModelPicker: () => null,
+	ModelPicker: ({ runtimeMode }: { runtimeMode: string }) => (
+		<span data-runtime-mode={runtimeMode} />
+	),
 }));
 
 vi.mock("../../src/lib/session-timeline-hooks.ts", async (original) => ({
@@ -41,5 +43,6 @@ describe("composer applied access", () => {
 		);
 		expect(html).toContain("Supervised");
 		expect(html).not.toContain("Full access");
+		expect(html).toContain('data-runtime-mode="approval-required"');
 	});
 });

--- a/apps/renderer/test/unit/permission-card.test.tsx
+++ b/apps/renderer/test/unit/permission-card.test.tsx
@@ -1,0 +1,42 @@
+import { EnvironmentId, PermissionRequest, SessionId } from "@zuse/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PermissionCard } from "../../src/components/permission-card.tsx";
+
+const request = PermissionRequest.make({
+	id: "approval-1",
+	sessionId: SessionId.make("cloud-session"),
+	kind: { _tag: "Bash", command: "git status" },
+	requestedAt: new Date(0),
+	forcePrompt: false,
+});
+
+describe("permission recovery presentation", () => {
+	it("keeps a live approval actionable regardless of its age", () => {
+		const html = renderToStaticMarkup(
+			<PermissionCard
+				head={request}
+				queueSize={1}
+				environmentId={EnvironmentId.make("cloud-1")}
+			/>,
+		);
+		expect(html).toContain("git status");
+		expect(html).toContain("Allow once");
+		expect(html).not.toContain("expired");
+	});
+	it("preserves an expired approval without offering unsafe approval actions", () => {
+		const html = renderToStaticMarkup(
+			<PermissionCard
+				head={PermissionRequest.make({ ...request, recoveryState: "expired" })}
+				queueSize={1}
+				environmentId={EnvironmentId.make("cloud-1")}
+			/>,
+		);
+		expect(html).toContain("git status");
+		expect(html).toContain("Approval expired after agent restart");
+		expect(html).toContain("Dismiss");
+		expect(html).not.toContain("Allow once");
+		expect(html).not.toContain("Always allow");
+		expect(html).toContain('aria-live="polite"');
+	});
+});

--- a/apps/renderer/test/unit/session-environment-routing.test.ts
+++ b/apps/renderer/test/unit/session-environment-routing.test.ts
@@ -3,12 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	dispatch: vi.fn(),
+	patchActive: vi.fn(),
 }));
 
 vi.mock("../../src/lib/environment-entities.ts", () => ({
 	activeSessionById: () => null,
 	activeSessionsByProject: () => ({}),
-	overlayActiveEnvironmentShell: () => false,
+	overlayActiveEnvironmentShell: mocks.patchActive,
 	overlayEnvironmentShell: () => false,
 }));
 
@@ -36,8 +37,30 @@ const { useSessionsStore } = await import("../../src/store/sessions.ts");
 describe("session command environment routing", () => {
 	beforeEach(() => {
 		mocks.dispatch.mockReset();
+		mocks.patchActive.mockReset();
 		mocks.dispatch.mockResolvedValue({ result: undefined });
 		useSessionsStore.setState({ draftSession: null, error: null });
+	});
+
+	it("does not claim Full Access before a cloud mode change is applied", async () => {
+		let reject!: (cause: Error) => void;
+		mocks.dispatch.mockReturnValueOnce(
+			new Promise((_, fail) => {
+				reject = fail;
+			}),
+		);
+		const changing = useSessionsStore
+			.getState()
+			.setRuntimeMode(
+				SessionId.make("cloud-session"),
+				"full-access",
+				EnvironmentId.make("cloud-workspace"),
+			);
+		expect(mocks.patchActive).not.toHaveBeenCalled();
+		reject(new Error("Runtime unavailable"));
+		await changing;
+		expect(mocks.patchActive).not.toHaveBeenCalled();
+		expect(useSessionsStore.getState().error).toBe("Runtime unavailable");
 	});
 
 	it("keeps a new cloud tab's provider mutation in its explicit workspace", async () => {

--- a/apps/server/src/provider/layers/permission-service.ts
+++ b/apps/server/src/provider/layers/permission-service.ts
@@ -6,6 +6,7 @@ import {
 	type PermissionKind,
 	PermissionRequest,
 	type PermissionRequestChange,
+	PermissionRequestExpiredError,
 	PermissionRequestNotFoundError,
 	SavedDecision,
 	type SessionId,
@@ -40,7 +41,6 @@ interface PendingEntry {
 	readonly request: PermissionRequest;
 	readonly deferred: Deferred.Deferred<PermissionDecision>;
 	readonly projectId: FolderId;
-	readonly recovered: boolean;
 }
 
 interface DecisionRow {
@@ -58,6 +58,7 @@ interface DecisionRow {
 interface PendingRequestRow {
 	readonly request_json: string;
 	readonly project_id: string;
+	readonly abandoned_turn_id: string | null;
 }
 
 /**
@@ -294,12 +295,24 @@ export const PermissionServiceLive = Layer.effect(
 		);
 
 		// The driver Deferred is process-local, but the prompt itself is durable.
-		// Recover unresolved entries in quarantine: the original provider process is
-		// gone, so the UI must not see the prompt until a matching replacement
-		// callback reattaches and can consume its decision.
+		// A restart destroys its provider callback, not its audit record. Keep the
+		// request visible as expired. Never attach a later, merely similar tool call
+		// to an old approval (a FileWrite key can match every edit in a checkout).
 		const unresolved = yield* sql<PendingRequestRow>`
       SELECT json_extract(requested.payload_json, '$.payloadJson') AS request_json,
-             sessions.project_id
+             sessions.project_id,
+             CASE WHEN sessions.current_turn_id IS NOT NULL AND (
+               json_extract(requested.payload_json, '$.turnId') = sessions.current_turn_id
+               OR (
+                 json_extract(requested.payload_json, '$.turnId') =
+                   json_extract(requested.payload_json, '$.requestId')
+                 AND NOT EXISTS (
+                   SELECT 1 FROM events AS later
+                   WHERE later.stream_kind = 'session' AND later.stream_id = requested.stream_id
+                     AND later.type = 'TurnStarted' AND later.sequence > requested.sequence
+                 )
+               )
+             ) THEN sessions.current_turn_id ELSE NULL END AS abandoned_turn_id
       FROM events AS requested
       JOIN sessions ON sessions.id = requested.stream_id
       WHERE requested.stream_kind = 'session'
@@ -323,10 +336,12 @@ export const PermissionServiceLive = Layer.effect(
 			yield* Ref.update(pending, (current) => {
 				const next = new Map(current);
 				next.set(recovered.id, {
-					request: recovered,
+					request: PermissionRequest.make({
+						...recovered,
+						recoveryState: "expired",
+					}),
 					deferred,
 					projectId: row.project_id as FolderId,
-					recovered: true,
 				});
 				return next;
 			});
@@ -335,6 +350,20 @@ export const PermissionServiceLive = Layer.effect(
 				sessionId: recovered.sessionId,
 				projectId: row.project_id,
 			});
+			if (row.abandoned_turn_id !== null) {
+				yield* sessionDomain
+					.dispatch({
+						commandId: `permission:expired-turn:${recovered.sessionId}:${row.abandoned_turn_id}`,
+						streamId: recovered.sessionId,
+						command: {
+							_tag: "SettleTurn",
+							turnId: row.abandoned_turn_id,
+							outcome: "interrupted",
+							settledAt: Date.now(),
+						},
+					})
+					.pipe(Effect.orDie);
+			}
 		}
 		yield* runPermissionReactor;
 
@@ -344,39 +373,6 @@ export const PermissionServiceLive = Layer.effect(
 			options,
 		) =>
 			Effect.gen(function* () {
-				const recovered = yield* Ref.modify(pending, (entries) => {
-					const entry = [...entries.values()].find(
-						(candidate) =>
-							candidate.recovered &&
-							candidate.request.sessionId === sessionId &&
-							candidate.projectId === options.projectId &&
-							candidate.request.kind._tag === kind._tag &&
-							kindKey(candidate.request.kind) === kindKey(kind) &&
-							candidate.request.forcePrompt === (options.forcePrompt === true),
-					);
-					if (entry === undefined) return [undefined, entries] as const;
-					const next = new Map(entries);
-					next.set(entry.request.id, { ...entry, recovered: false });
-					return [entry, next] as const;
-				});
-				if (recovered !== undefined) {
-					log("request.reattached", {
-						requestId: recovered.request.id,
-						sessionId,
-						projectId: options.projectId,
-						kindTag: kind._tag,
-						kindKey: kindKey(kind),
-					});
-					// A recovered request has no live provider callback until this
-					// matching request reattaches. Publish it only now so the renderer
-					// cannot resolve a prompt whose original turn is already gone.
-					yield* PubSub.publish(pubsub, {
-						_tag: "change",
-						request: recovered.request,
-					});
-					return yield* Deferred.await(recovered.deferred);
-				}
-
 				if (options.forcePrompt !== true) {
 					const allowed = yield* findExistingAllow(
 						sessionId,
@@ -409,7 +405,6 @@ export const PermissionServiceLive = Layer.effect(
 						request: req,
 						deferred,
 						projectId: options.projectId,
-						recovered: false,
 					});
 					log("request.pending_added", {
 						requestId: id,
@@ -422,6 +417,9 @@ export const PermissionServiceLive = Layer.effect(
 					});
 					return next;
 				});
+				const [owner] = yield* sql<{ readonly current_turn_id: string | null }>`
+					SELECT current_turn_id FROM sessions WHERE id = ${sessionId}
+				`.pipe(Effect.orDie);
 				yield* sessionDomain
 					.dispatch({
 						commandId: `permission:request:${id}`,
@@ -429,7 +427,7 @@ export const PermissionServiceLive = Layer.effect(
 						command: {
 							_tag: "RequestPermission",
 							requestId: id,
-							turnId: id,
+							turnId: owner?.current_turn_id ?? id,
 							payloadJson: JSON.stringify(req),
 							requestedAt: req.requestedAt.getTime(),
 						},
@@ -459,6 +457,14 @@ export const PermissionServiceLive = Layer.effect(
 						new PermissionRequestNotFoundError({ requestId }),
 					);
 				}
+				if (
+					entry.request.recoveryState === "expired" &&
+					decision._tag !== "Deny"
+				) {
+					return yield* Effect.fail(
+						new PermissionRequestExpiredError({ requestId }),
+					);
+				}
 				yield* sessionDomain
 					.dispatch({
 						commandId: `permission:resolve:${requestId}`,
@@ -480,7 +486,7 @@ export const PermissionServiceLive = Layer.effect(
 				const map = yield* Ref.get(pending);
 				const out: PermissionRequest[] = [];
 				for (const entry of map.values()) {
-					if (!entry.recovered && entry.request.sessionId === sessionId) {
+					if (entry.request.sessionId === sessionId) {
 						out.push(entry.request);
 					}
 				}
@@ -497,9 +503,9 @@ export const PermissionServiceLive = Layer.effect(
 				Effect.gen(function* () {
 					const dequeue = yield* PubSub.subscribe(pubsub);
 					const map = yield* Ref.get(pending);
-					const current = Array.from(map.values())
-						.filter((entry) => !entry.recovered)
-						.map((entry) => entry.request);
+					const current = Array.from(map.values()).map(
+						(entry) => entry.request,
+					);
 					log("stream.subscribe", {
 						replayCount: current.length,
 						requestIds: current.map((req) => req.id),

--- a/apps/server/src/provider/services/permission-service.ts
+++ b/apps/server/src/provider/services/permission-service.ts
@@ -4,6 +4,7 @@ import type {
 	PermissionKind,
 	PermissionRequest,
 	PermissionRequestChange,
+	PermissionRequestExpiredError,
 	PermissionRequestNotFoundError,
 	SavedDecision,
 	SessionId,
@@ -49,7 +50,10 @@ export interface PermissionServiceShape {
 	readonly decide: (
 		requestId: string,
 		decision: PermissionDecision,
-	) => Effect.Effect<void, PermissionRequestNotFoundError>;
+	) => Effect.Effect<
+		void,
+		PermissionRequestNotFoundError | PermissionRequestExpiredError
+	>;
 
 	readonly listPending: (
 		sessionId: SessionId,

--- a/apps/server/test/integration/permission-service-restart.test.ts
+++ b/apps/server/test/integration/permission-service-restart.test.ts
@@ -7,7 +7,7 @@ import { SessionDomain } from "@zuse/domain/engine/session-domain";
 import { layer as sqliteLayer } from "@zuse/sqlite";
 import { Effect, Fiber, Layer, ManagedRuntime, Stream } from "effect";
 import { SqlClient } from "effect/unstable/sql";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { AppPaths } from "../../src/app-paths.ts";
 import { PermissionServiceLive } from "../../src/provider/layers/permission-service.ts";
 import type { PermissionServiceShape } from "../../src/provider/services/permission-service.ts";
@@ -16,6 +16,7 @@ import { PermissionService } from "../../src/provider/services/permission-servic
 const directories: string[] = [];
 
 afterEach(() => {
+	vi.useRealTimers();
 	for (const directory of directories.splice(0)) {
 		rmSync(directory, { recursive: true, force: true });
 	}
@@ -138,6 +139,11 @@ const createSession = Effect.gen(function* () {
 			createdAt: 1,
 		},
 	});
+	yield* domain.dispatch({
+		commandId: "start-turn",
+		streamId: "session-1",
+		command: { _tag: "StartTurn", turnId: "turn-1", startedAt: 2 },
+	});
 });
 
 describe("PermissionService restart recovery", () => {
@@ -154,7 +160,150 @@ describe("PermissionService restart recovery", () => {
 			),
 		);
 
-	test("publishes a recovered request only after its provider reattaches", async () => {
+	test.each([
+		false,
+		true,
+	])("recovers legacy approval records without settling a newer turn (newer=%s)", async (newer) => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-permission-legacy-"));
+		directories.push(directory);
+		const filename = join(directory, "test.sqlite");
+		const schemaRuntime = ManagedRuntime.make(sqliteLayer({ filename }));
+		await schemaRuntime.runPromise(createSchema);
+		await schemaRuntime.dispose();
+		const first = makeRuntime(filename, directory);
+		await first.runPromise(createSession);
+		// Reproduce the old runtime's event: turnId incorrectly held requestId.
+		await first.runPromise(
+			Effect.gen(function* () {
+				const domain = yield* SessionDomain;
+				yield* domain.dispatch({
+					commandId: "legacy-request",
+					streamId: "session-1",
+					command: {
+						_tag: "RequestPermission",
+						requestId: "legacy",
+						turnId: "legacy",
+						requestedAt: 3,
+						payloadJson: JSON.stringify(
+							PermissionRequest.make({
+								id: "legacy",
+								sessionId: SessionId.make("session-1"),
+								kind: { _tag: "Bash", command: "git status" },
+								requestedAt: new Date(3),
+								forcePrompt: false,
+							}),
+						),
+					},
+				});
+				if (newer) {
+					yield* domain.dispatch({
+						commandId: "settle-old",
+						streamId: "session-1",
+						command: {
+							_tag: "SettleTurn",
+							turnId: "turn-1",
+							outcome: "interrupted",
+							settledAt: 4,
+						},
+					});
+					yield* domain.dispatch({
+						commandId: "start-new",
+						streamId: "session-1",
+						command: { _tag: "StartTurn", turnId: "turn-2", startedAt: 5 },
+					});
+				}
+			}),
+		);
+		await first.dispose();
+		const restarted = makeRuntime(filename, directory);
+		try {
+			const rows = await restarted.runPromise(
+				Effect.flatMap(
+					SqlClient.SqlClient,
+					(sql) =>
+						sql`SELECT current_turn_id FROM sessions WHERE id = 'session-1'`,
+				),
+			);
+			expect(rows).toEqual([{ current_turn_id: newer ? "turn-2" : null }]);
+			expect(
+				await restarted.runPromise(
+					Effect.flatMap(PermissionService, (service) =>
+						service.listPending(SessionId.make("session-1")),
+					),
+				),
+			).toEqual([
+				expect.objectContaining({ id: "legacy", recoveryState: "expired" }),
+			]);
+		} finally {
+			await restarted.dispose();
+		}
+	});
+
+	test("replays a live approval when the first client arrives thirty minutes late", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "zuse-permission-offline-"));
+		directories.push(directory);
+		const filename = join(directory, "test.sqlite");
+		const schemaRuntime = ManagedRuntime.make(sqliteLayer({ filename }));
+		await schemaRuntime.runPromise(createSchema);
+		await schemaRuntime.dispose();
+		const runtime = makeRuntime(filename, directory);
+		await runtime.runPromise(createSession);
+		const callback = runtime.runFork(
+			Effect.flatMap(PermissionService, (service) =>
+				service.request(
+					SessionId.make("session-1"),
+					{ _tag: "Bash", command: "git status" },
+					{ projectId: FolderId.make("project-1") },
+				),
+			),
+		);
+		try {
+			// No client subscription while the provider creates and persists its ask.
+			await runtime.runPromise(
+				Effect.gen(function* () {
+					const sql = yield* SqlClient.SqlClient;
+					while (
+						(yield* sql`SELECT sequence FROM events WHERE type = 'PermissionRequested'`)
+							.length === 0
+					)
+						yield* Effect.yieldNow;
+				}).pipe(Effect.timeout(1_000)),
+			);
+			vi.useFakeTimers({ toFake: ["Date"] });
+			vi.setSystemTime(Date.now() + 30 * 60 * 1_000);
+			const reconnect = () =>
+				runtime.runPromise(
+					Effect.flatMap(PermissionService, (service) =>
+						service.requests().pipe(Stream.take(1), Stream.runCollect),
+					),
+				);
+			const [snapshot] = await reconnect();
+			expect(snapshot?._tag).toBe("snapshot");
+			if (snapshot?._tag !== "snapshot") throw new Error("Missing snapshot");
+			const pending = snapshot.requests[0];
+			expect(pending?.recoveryState).toBeUndefined();
+			expect(pending?.requestedAt.getTime()).toBeLessThanOrEqual(
+				Date.now() - 30 * 60 * 1_000,
+			);
+			expect(await reconnect()).toEqual([snapshot]);
+			await runtime.runPromise(
+				Effect.flatMap(PermissionService, (service) =>
+					service.decide(pending?.id ?? "missing", { _tag: "AllowOnce" }),
+				),
+			);
+			expect(
+				await Effect.runPromise(
+					Fiber.join(callback).pipe(Effect.timeout(1_000)),
+				),
+			).toEqual({ _tag: "AllowOnce" });
+			expect(await reconnect()).toEqual([{ _tag: "snapshot", requests: [] }]);
+		} finally {
+			await Effect.runPromise(Fiber.interrupt(callback));
+			await runtime.dispose();
+		}
+	});
+
+	test("keeps a restarted approval visible but never reuses it for a new tool call", async () => {
 		const directory = mkdtempSync(join(tmpdir(), "zuse-permission-restart-"));
 		directories.push(directory);
 		const filename = join(directory, "test.sqlite");
@@ -191,10 +340,41 @@ describe("PermissionService restart recovery", () => {
 					service.listPending(SessionId.make("session-1")),
 				),
 			);
-			expect(pending).toEqual([]);
+			expect(pending).toEqual([
+				expect.objectContaining({
+					id: published?.id,
+					recoveryState: "expired",
+				}),
+			]);
+			expect(
+				await restarted.runPromise(
+					Effect.flatMap(PermissionService, (service) =>
+						service.requests().pipe(Stream.take(1), Stream.runCollect),
+					),
+				),
+			).toEqual([{ _tag: "snapshot", requests: pending }]);
+			await expect(
+				restarted.runPromise(
+					Effect.flatMap(PermissionService, (service) =>
+						service.decide(published?.id ?? "missing", {
+							_tag: "AlwaysAllow",
+							scope: "folder",
+						}),
+					),
+				),
+			).rejects.toMatchObject({ _tag: "PermissionRequestExpiredError" });
+			const session = await restarted.runPromise(
+				Effect.flatMap(
+					SqlClient.SqlClient,
+					(sql) =>
+						sql`SELECT status, current_turn_id FROM sessions WHERE id = 'session-1'`,
+				),
+			);
+			expect(session).toEqual([{ status: "idle", current_turn_id: null }]);
 			const republished = restarted.runFork(
 				Effect.flatMap(PermissionService, (service) =>
 					permissionRequests(service.requests()).pipe(
+						Stream.filter((request) => request.id !== published?.id),
 						Stream.take(1),
 						Stream.runCollect,
 					),
@@ -213,17 +393,17 @@ describe("PermissionService restart recovery", () => {
 			const [liveRequest] = await Effect.runPromise(
 				Fiber.join(republished).pipe(Effect.timeout(1_000)),
 			);
-			expect(liveRequest?.id).toBe(published?.id);
+			expect(liveRequest?.id).not.toBe(published?.id);
 			expect(
 				await restarted.runPromise(
 					Effect.flatMap(PermissionService, (service) =>
 						service.listPending(SessionId.make("session-1")),
 					),
 				),
-			).toEqual([liveRequest]);
+			).toEqual([pending[0], liveRequest]);
 			await restarted.runPromise(
 				Effect.flatMap(PermissionService, (service) =>
-					service.decide(published?.id ?? "missing", { _tag: "AllowOnce" }),
+					service.decide(liveRequest?.id ?? "missing", { _tag: "AllowOnce" }),
 				),
 			);
 			await expect(
@@ -235,17 +415,42 @@ describe("PermissionService restart recovery", () => {
 						service.listPending(SessionId.make("session-1")),
 					),
 				),
-			).toEqual([]);
+			).toEqual(pending);
 			const decisions = await restarted.runPromise(
 				Effect.flatMap(PermissionService, (service) =>
 					service.listDecisions({ projectId: FolderId.make("project-1") }),
 				),
 			);
 			expect(decisions.map((decision) => decision.requestId)).toEqual([
-				published?.id,
+				liveRequest?.id,
 			]);
+			await restarted.runPromise(
+				Effect.flatMap(PermissionService, (service) =>
+					service.decide(published?.id ?? "missing", { _tag: "Deny" }),
+				),
+			);
 		} finally {
 			await restarted.dispose();
+		}
+		const secondRestart = makeRuntime(filename, directory);
+		try {
+			expect(
+				await secondRestart.runPromise(
+					Effect.flatMap(PermissionService, (service) =>
+						service.listPending(SessionId.make("session-1")),
+					),
+				),
+			).toEqual([]);
+			const [settlements] = await secondRestart.runPromise(
+				Effect.flatMap(
+					SqlClient.SqlClient,
+					(sql) =>
+						sql`SELECT count(*) AS count FROM events WHERE type = 'TurnSettled'`,
+				),
+			);
+			expect(settlements?.count).toBe(1);
+		} finally {
+			await secondRestart.dispose();
 		}
 	});
 });

--- a/packages/client-runtime/src/plan-interactions.ts
+++ b/packages/client-runtime/src/plan-interactions.ts
@@ -25,6 +25,7 @@ export const isPlanApprovalRequest = (
 	sessionId: SessionId,
 ): boolean =>
 	request.sessionId === sessionId &&
+	request.recoveryState !== "expired" &&
 	request.kind._tag === "Other" &&
 	request.kind.tool === "ExitPlanMode";
 

--- a/packages/client-runtime/test/unit/plan-interactions.test.ts
+++ b/packages/client-runtime/test/unit/plan-interactions.test.ts
@@ -1,8 +1,13 @@
-import type { Message, SessionId } from "@zuse/contracts";
+import {
+	type Message,
+	PermissionRequest,
+	type SessionId,
+} from "@zuse/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
 	findPendingNativePlanApproval,
+	findPendingPlanApprovalRequest,
 	findPendingPlanInteraction,
 } from "../../src/plan-interactions";
 
@@ -17,6 +22,17 @@ const message = (id: string, content: Message["content"]): Message =>
 	}) as Message;
 
 describe("pending plan interactions", () => {
+	it("does not route an expired permission into an actionable plan card", () => {
+		const request = PermissionRequest.make({
+			id: "expired-plan",
+			sessionId,
+			kind: { _tag: "Other", tool: "ExitPlanMode", summary: "Plan" },
+			requestedAt: new Date(),
+			forcePrompt: true,
+			recoveryState: "expired",
+		});
+		expect(findPendingPlanApprovalRequest([request], sessionId)).toBeNull();
+	});
 	it("selects only the newest unresolved exact plan", () => {
 		const old = message("old", {
 			_tag: "tool_use",

--- a/packages/contracts/src/permission.ts
+++ b/packages/contracts/src/permission.ts
@@ -65,6 +65,8 @@ export class PermissionRequest extends Schema.Class<PermissionRequest>(
 	 * bash/network prompts almost never are; they usually mean plan mode.
 	 */
 	forcePrompt: Schema.Boolean,
+	/** The original process-local provider callback no longer exists. */
+	recoveryState: Schema.optional(Schema.Literal("expired")),
 }) {}
 
 /**
@@ -91,6 +93,11 @@ export class SavedDecision extends Schema.Class<SavedDecision>("SavedDecision")(
 
 export class PermissionRequestNotFoundError extends Schema.TaggedErrorClass<PermissionRequestNotFoundError>()(
 	"PermissionRequestNotFoundError",
+	{ requestId: Schema.String },
+) {}
+
+export class PermissionRequestExpiredError extends Schema.TaggedErrorClass<PermissionRequestExpiredError>()(
+	"PermissionRequestExpiredError",
 	{ requestId: Schema.String },
 ) {}
 
@@ -132,7 +139,10 @@ export const PermissionDecideRpc = Rpc.make("permission.decide", {
 		decision: PermissionDecision,
 	}),
 	success: Schema.Void,
-	error: PermissionRequestNotFoundError,
+	error: Schema.Union([
+		PermissionRequestNotFoundError,
+		PermissionRequestExpiredError,
+	]),
 });
 
 /**


### PR DESCRIPTION
## Summary

Fix the three access/approval failures reported in cloud chats:

- Resolve the user's persisted default before creating a chat, including cold startup. Preserve destination repository overrides, but do not replace the user's global preference with the sandbox image's settings. Never interpret an unhydrated settings fallback as the user's access choice. Keep settings reads in ClientBus and provide retry if loading fails.
- Render access from the authoritative, environment-qualified session timeline. A mode change no longer optimistically advertises Full Access before the runtime commits it. Show checking/updating states and preserve draft choices.
- Replay live approvals to clients that arrive later. After a runtime process restart, preserve the request as explicitly expired, reject attempts to approve its dead callback, and settle only the abandoned turn. Remove unsafe matching of old approvals to later tool calls by path/command. Support legacy events that incorrectly stored request ID as turn ID, without settling newer turns.
- Desktop and mobile show expired-request guidance with Dismiss; expired plan permissions cannot be offered as actionable approvals. No automatic provider replay or silent permission escalation.

## Evidence and tests

Regression tests were observed failing on the original paths for cold-start defaults, premature Full Access, actual composer markup using a stale catalog row, and missing approval recovery. Tests use the real permission service, SQLite, domain event persistence, client dispatch, and rendered composer/approval components.

- Renderer: 776 tests passed (153 files).
- Permission restart/reconnect integration: 4 tests passed, including a simulated 30-minute-late first subscriber, restart, same-kind new request fencing, durable dismissal, and legacy/newer-turn cases.
- Existing cloud runtime/bootstrap tests: 37 passed, including Full Access propagation through launch replay.
- Client runtime: 153 tests passed. Mobile: 278 passed. Contracts: 148 passed. Domain: 96 passed. API: 278 passed.
- Type checks passed for renderer, runtime, mobile, client-runtime, contracts, domain, API and dependencies (24 tasks).
- Applicable Biome checks passed with five pre-existing non-null assertion warnings in chat-composer.tsx. Architecture, renderer-state, API terminology, and diff checks passed.
- Renderer production build and bundle budgets passed: initial JS 75.2 KiB gzip, default route 494.3 KiB gzip (500 KiB budget).

### Existing main failure, not hidden

The broad server suite passed 636/637 tests at the time of the run. `ConversationServices — provider event persistence > keeps pending New chat titles when the first turn errors` failed with `first turn has not failed yet`. The exact isolated command also fails in a separate untouched origin/main worktree at `0b687154`. That test does not instantiate PermissionService; the affected conversation implementation is unchanged. No unrelated timing/test changes are included.

## Deployment

No API, image, database, or DO migration changes. This PR needs a desktop/runtime release to reach production clients and sandboxes; merely redeploying the API will not install these fixes. No user's sandbox was restarted or approved during verification. Existing Full Access defaults do not retroactively change retained sessions: the corrected UI shows their actual applied mode, which the user can explicitly change.

